### PR TITLE
re-implement more create vault tests

### DIFF
--- a/contracts/dca/src/handlers/create_vault.rs
+++ b/contracts/dca/src/handlers/create_vault.rs
@@ -8,6 +8,7 @@ use crate::helpers::validation_helpers::{
     assert_target_start_time_is_in_future,
 };
 use crate::helpers::vault_helpers::get_dca_plus_model_id;
+use crate::msg::ExecuteMsg;
 use crate::state::cache::{Cache, CACHE};
 use crate::state::config::get_config;
 use crate::state::events::create_event;
@@ -20,12 +21,10 @@ use crate::types::vault_builder::VaultBuilder;
 use base::events::event::{EventBuilder, EventData};
 use base::triggers::trigger::{TimeInterval, Trigger, TriggerConfiguration};
 use base::vaults::vault::{Destination, PostExecutionAction, VaultStatus};
-use cosmwasm_std::{coin, Addr, Decimal};
+use cosmwasm_std::{coin, to_binary, Addr, CosmosMsg, Decimal, WasmMsg};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::{DepsMut, Env, MessageInfo, Response, Timestamp, Uint128, Uint64};
 use osmosis_helpers::position_type::PositionType;
-
-use super::execute_trigger::execute_trigger;
 
 pub fn create_vault(
     mut deps: DepsMut,
@@ -170,7 +169,7 @@ pub fn create_vault(
 
     match (target_start_time_utc_seconds, target_receive_amount) {
         (None, None) | (Some(_), None) => {
-            let response = create_time_trigger(
+            let mut response = create_time_trigger(
                 &mut deps,
                 &env,
                 &vault,
@@ -180,9 +179,14 @@ pub fn create_vault(
             .expect("time trigger created");
 
             if target_start_time_utc_seconds.is_none() {
-                return Ok(
-                    execute_trigger(deps, env, vault.id, response).expect("time trigger executed")
-                );
+                response = response.add_message(CosmosMsg::Wasm(WasmMsg::Execute {
+                    contract_addr: env.contract.address.to_string(),
+                    msg: to_binary(&ExecuteMsg::ExecuteTrigger {
+                        trigger_id: vault.id,
+                    })
+                    .unwrap(),
+                    funds: vec![],
+                }));
             }
 
             Ok(response)

--- a/contracts/dca/src/tests/create_vault_tests.rs
+++ b/contracts/dca/src/tests/create_vault_tests.rs
@@ -1,27 +1,21 @@
-use super::mocks::{fin_contract_fail_slippage_tolerance, fin_contract_pass_slippage_tolerance};
-use crate::constants::{ONE, ONE_THOUSAND, TEN, TWO_MICRONS};
+use crate::handlers::create_pool::create_pool;
 use crate::handlers::create_vault::create_vault;
-use crate::msg::{ExecuteMsg, QueryMsg, VaultResponse};
-use crate::state::config::{get_config, update_config, Config, FeeCollector};
-use crate::tests::helpers::{
-    assert_address_balances, assert_events_published, assert_vault_balance, instantiate_contract,
-};
-use crate::tests::instantiate_tests::VALID_ADDRESS_ONE;
-use crate::tests::mocks::{
-    fin_contract_unfilled_limit_order, MockApp, ADMIN, DENOM_STAKE, DENOM_UOSMO, USER,
-};
+use crate::handlers::get_events_by_resource_id::get_events_by_resource_id;
+use crate::handlers::get_vault::get_vault;
+use crate::msg::ExecuteMsg;
+use crate::state::config::{get_config, update_config, Config};
+use crate::tests::helpers::instantiate_contract;
+use crate::tests::mocks::{ADMIN, DENOM_STAKE, DENOM_UOSMO, USER};
 use crate::types::dca_plus_config::DcaPlusConfig;
 use crate::types::vault::Vault;
 use base::events::event::{EventBuilder, EventData};
-use base::helpers::math_helpers::checked_mul;
-use base::helpers::message_helpers::get_flat_map_for_event_type;
 use base::pool::Pool;
 use base::triggers::trigger::{TimeInterval, TriggerConfiguration};
 use base::vaults::vault::{Destination, PostExecutionAction, VaultStatus};
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-use cosmwasm_std::{Addr, Coin, Decimal, Decimal256, Uint128, Uint64};
-use cw_multi_test::Executor;
-use std::str::FromStr;
+use cosmwasm_std::{
+    to_binary, Addr, Coin, CosmosMsg, Decimal, SubMsg, Timestamp, Uint128, WasmMsg,
+};
 
 #[test]
 fn with_no_assets_should_fail() {
@@ -35,7 +29,7 @@ fn with_no_assets_should_fail() {
         deps.as_mut(),
         env,
         &info,
-        Addr::unchecked(USER),
+        info.sender.clone(),
         None,
         vec![],
         0,
@@ -71,7 +65,7 @@ fn with_multiple_assets_should_fail() {
         deps.as_mut(),
         env,
         &info,
-        Addr::unchecked(USER),
+        info.sender.clone(),
         None,
         vec![],
         0,
@@ -104,7 +98,7 @@ fn with_non_existent_pool_id_should_fail() {
         deps.as_mut(),
         env,
         &info,
-        Addr::unchecked(USER),
+        info.sender.clone(),
         None,
         vec![],
         0,
@@ -134,7 +128,7 @@ fn with_destination_allocations_less_than_100_percent_should_fail() {
         deps.as_mut(),
         env,
         &info,
-        Addr::unchecked(USER),
+        info.sender.clone(),
         None,
         vec![Destination {
             address: Addr::unchecked("destination"),
@@ -171,7 +165,7 @@ fn with_destination_allocation_equal_to_zero_should_fail() {
         deps.as_mut(),
         env,
         &info,
-        Addr::unchecked(USER),
+        info.sender.clone(),
         None,
         vec![
             Destination {
@@ -215,7 +209,7 @@ fn with_more_than_10_destination_allocations_should_fail() {
         deps.as_mut(),
         env,
         &info,
-        Addr::unchecked(USER),
+        info.sender.clone(),
         None,
         (0..20)
             .into_iter()
@@ -255,7 +249,7 @@ fn with_swap_amount_less_than_50000_should_fail() {
         deps.as_mut(),
         env,
         &info,
-        Addr::unchecked(USER),
+        info.sender.clone(),
         None,
         vec![],
         0,
@@ -299,7 +293,7 @@ fn when_contract_is_paused_should_fail() {
         deps.as_mut(),
         env,
         &info,
-        Addr::unchecked(USER),
+        info.sender.clone(),
         None,
         vec![],
         0,
@@ -329,7 +323,7 @@ fn with_time_trigger_with_target_time_in_the_past_should_fail() {
         deps.as_mut(),
         env.clone(),
         &info,
-        Addr::unchecked(USER),
+        info.sender.clone(),
         None,
         vec![],
         0,
@@ -351,707 +345,64 @@ fn with_time_trigger_with_target_time_in_the_past_should_fail() {
 }
 
 #[test]
-fn with_immediate_time_trigger_should_update_address_balances() {
-    let user_address = Addr::unchecked(USER);
-    let user_balance = TEN;
-    let vault_deposit = TEN;
-    let swap_amount = ONE;
-    let mut mock = MockApp::new(fin_contract_pass_slippage_tolerance()).with_funds_for(
-        &user_address,
-        user_balance,
-        DENOM_UOSMO,
-    );
+fn should_create_vault() {
+    let mut deps = mock_dependencies();
+    let env = mock_env();
+    let mut info = mock_info(ADMIN, &[]);
 
-    assert_address_balances(
-        &mock,
-        &[
-            (&user_address, DENOM_UOSMO, user_balance),
-            (&user_address, DENOM_STAKE, Uint128::new(0)),
-            (&mock.dca_contract_address, DENOM_UOSMO, ONE_THOUSAND),
-            (&mock.dca_contract_address, DENOM_STAKE, ONE_THOUSAND),
-            (&mock.fin_contract_address, DENOM_UOSMO, ONE_THOUSAND),
-            (&mock.fin_contract_address, DENOM_STAKE, ONE_THOUSAND),
-        ],
-    );
+    instantiate_contract(deps.as_mut(), env.clone(), info.clone());
 
-    mock.app
-        .execute_contract(
-            Addr::unchecked(USER),
-            mock.dca_contract_address.clone(),
-            &ExecuteMsg::CreateVault {
-                owner: None,
-                minimum_receive_amount: None,
-                label: Some("label".to_string()),
-                destinations: None,
-                pool_id: 0,
-                position_type: None,
-                slippage_tolerance: None,
-                swap_amount,
-                time_interval: TimeInterval::Hourly,
-                target_start_time_utc_seconds: None,
-                target_receive_amount: None,
-                use_dca_plus: None,
-            },
-            &vec![Coin::new(vault_deposit.into(), DENOM_UOSMO)],
-        )
-        .unwrap();
-
-    let fee_amount = checked_mul(swap_amount, mock.fee_percent).ok().unwrap();
-
-    assert_address_balances(
-        &mock,
-        &[
-            (&user_address, DENOM_UOSMO, user_balance - vault_deposit),
-            (&user_address, DENOM_STAKE, swap_amount - fee_amount),
-            (
-                &mock.dca_contract_address,
-                DENOM_UOSMO,
-                ONE_THOUSAND + user_balance - swap_amount,
-            ),
-            (&mock.dca_contract_address, DENOM_STAKE, ONE_THOUSAND),
-            (
-                &mock.fin_contract_address,
-                DENOM_UOSMO,
-                ONE_THOUSAND + swap_amount,
-            ),
-            (
-                &mock.fin_contract_address,
-                DENOM_STAKE,
-                ONE_THOUSAND - swap_amount,
-            ),
-        ],
-    );
-}
-
-#[test]
-fn with_immediate_time_trigger_should_update_vault_balance() {
-    let user_address = Addr::unchecked(USER);
-    let user_balance = TEN;
-    let vault_deposit = TEN;
-    let swap_amount = ONE;
-    let mut mock = MockApp::new(fin_contract_pass_slippage_tolerance()).with_funds_for(
-        &user_address,
-        user_balance,
-        DENOM_UOSMO,
-    );
-
-    mock.app
-        .execute_contract(
-            Addr::unchecked(USER),
-            mock.dca_contract_address.clone(),
-            &ExecuteMsg::CreateVault {
-                owner: None,
-                minimum_receive_amount: None,
-                label: Some("label".to_string()),
-                destinations: None,
-                pool_id: 0,
-                position_type: None,
-                slippage_tolerance: None,
-                swap_amount,
-                time_interval: TimeInterval::Hourly,
-                target_start_time_utc_seconds: None,
-                target_receive_amount: None,
-                use_dca_plus: None,
-            },
-            &vec![Coin::new(vault_deposit.into(), DENOM_UOSMO)],
-        )
-        .unwrap();
-
-    assert_vault_balance(
-        &mock,
-        &mock.dca_contract_address,
-        user_address,
-        Uint128::new(1),
-        vault_deposit - swap_amount,
-    );
-}
-
-#[test]
-fn with_immediate_time_trigger_should_create_active_vault() {
-    let user_address = Addr::unchecked(USER);
-    let user_balance = TEN;
-    let vault_deposit = TEN;
-    let swap_amount = ONE;
-    let mut mock = MockApp::new(fin_contract_pass_slippage_tolerance()).with_funds_for(
-        &user_address,
-        user_balance,
-        DENOM_UOSMO,
-    );
-
-    mock.app
-        .execute_contract(
-            Addr::unchecked(USER),
-            mock.dca_contract_address.clone(),
-            &ExecuteMsg::CreateVault {
-                owner: None,
-                minimum_receive_amount: None,
-                label: Some("label".to_string()),
-                destinations: None,
-                pool_id: 0,
-                position_type: None,
-                slippage_tolerance: None,
-                swap_amount,
-                time_interval: TimeInterval::Hourly,
-                target_start_time_utc_seconds: None,
-                target_receive_amount: None,
-                use_dca_plus: None,
-            },
-            &vec![Coin::new(vault_deposit.into(), DENOM_UOSMO)],
-        )
-        .unwrap();
-
-    let vault_id = Uint128::new(1);
-
-    let vault_response: VaultResponse = mock
-        .app
-        .wrap()
-        .query_wasm_smart(&mock.dca_contract_address, &QueryMsg::GetVault { vault_id })
-        .unwrap();
-
-    assert_eq!(
-        vault_response.vault,
-        Vault {
-            minimum_receive_amount: None,
-            label: Some("label".to_string()),
-            id: vault_id,
-            owner: user_address.clone(),
-            destinations: vec![Destination {
-                address: user_address.clone(),
-                allocation: Decimal::percent(100),
-                action: PostExecutionAction::Send
-            }],
-            created_at: mock.app.block_info().time,
-            status: VaultStatus::Active,
-            time_interval: TimeInterval::Hourly,
-            balance: Coin::new(
-                (vault_deposit - swap_amount).into(),
-                DENOM_UOSMO.to_string()
-            ),
-            slippage_tolerance: None,
-            swap_amount,
-            pool: Pool {
-                pool_id: 0,
-                base_denom: DENOM_STAKE.to_string(),
-                quote_denom: DENOM_UOSMO.to_string(),
-            },
-            started_at: Some(mock.app.block_info().time),
-            swapped_amount: Coin::new(swap_amount.into(), DENOM_UOSMO.to_string()),
-            received_amount: Coin::new(
-                (swap_amount - checked_mul(swap_amount, mock.fee_percent).ok().unwrap()).into(),
-                DENOM_STAKE.to_string()
-            ),
-            trigger: Some(TriggerConfiguration::Time {
-                target_time: mock
-                    .app
-                    .block_info()
-                    .time
-                    .plus_seconds(60 * 60)
-                    .minus_nanos(mock.app.block_info().time.subsec_nanos()),
-            }),
-            dca_plus_config: None,
-        }
-    );
-}
-
-#[test]
-fn with_immediate_time_trigger_should_publish_events() {
-    let user_address = Addr::unchecked(USER);
-    let user_balance = TEN;
-    let vault_deposit = TEN;
-    let swap_amount = ONE;
-    let mut mock = MockApp::new(fin_contract_pass_slippage_tolerance()).with_funds_for(
-        &user_address,
-        user_balance,
-        DENOM_UOSMO,
-    );
-
-    mock.app
-        .execute_contract(
-            Addr::unchecked(USER),
-            mock.dca_contract_address.clone(),
-            &ExecuteMsg::CreateVault {
-                owner: None,
-                minimum_receive_amount: None,
-                label: Some("label".to_string()),
-                destinations: None,
-                pool_id: 0,
-                position_type: None,
-                slippage_tolerance: None,
-                swap_amount,
-                time_interval: TimeInterval::Hourly,
-                target_start_time_utc_seconds: None,
-                target_receive_amount: None,
-                use_dca_plus: None,
-            },
-            &vec![Coin::new(vault_deposit.into(), DENOM_UOSMO)],
-        )
-        .unwrap();
-
-    let vault_id = Uint128::new(1);
-
-    assert_events_published(
-        &mock,
-        vault_id,
-        &[
-            EventBuilder::new(
-                vault_id,
-                mock.app.block_info(),
-                EventData::DcaVaultCreated {},
-            )
-            .build(1),
-            EventBuilder::new(
-                vault_id,
-                mock.app.block_info(),
-                EventData::DcaVaultFundsDeposited {
-                    amount: Coin::new(vault_deposit.into(), DENOM_UOSMO),
-                },
-            )
-            .build(2),
-            EventBuilder::new(
-                vault_id,
-                mock.app.block_info(),
-                EventData::DcaVaultExecutionTriggered {
-                    base_denom: DENOM_STAKE.to_string(),
-                    quote_denom: DENOM_UOSMO.to_string(),
-                    asset_price: Decimal::from_str("1.0").unwrap(),
-                },
-            )
-            .build(3),
-            EventBuilder::new(
-                vault_id,
-                mock.app.block_info(),
-                EventData::DcaVaultExecutionCompleted {
-                    sent: Coin::new(swap_amount.into(), DENOM_UOSMO),
-                    received: Coin::new(swap_amount.into(), DENOM_STAKE),
-                    fee: Coin::new(
-                        (checked_mul(swap_amount, mock.fee_percent).ok().unwrap()).into(),
-                        DENOM_STAKE,
-                    ),
-                },
-            )
-            .build(4),
-        ],
-    );
-}
-
-#[test]
-fn with_immediate_time_trigger_and_slippage_failure_should_update_address_balances() {
-    let user_address = Addr::unchecked(USER);
-    let user_balance = TEN;
-    let vault_deposit = TEN;
-    let swap_amount = ONE;
-    let mut mock = MockApp::new(fin_contract_fail_slippage_tolerance()).with_funds_for(
-        &user_address,
-        user_balance,
-        DENOM_UOSMO,
-    );
-
-    assert_address_balances(
-        &mock,
-        &[
-            (&user_address, DENOM_UOSMO, user_balance),
-            (&user_address, DENOM_STAKE, Uint128::new(0)),
-            (&mock.dca_contract_address, DENOM_UOSMO, ONE_THOUSAND),
-            (&mock.dca_contract_address, DENOM_STAKE, ONE_THOUSAND),
-            (&mock.fin_contract_address, DENOM_UOSMO, ONE_THOUSAND),
-            (&mock.fin_contract_address, DENOM_STAKE, ONE_THOUSAND),
-        ],
-    );
-
-    mock.app
-        .execute_contract(
-            Addr::unchecked(USER),
-            mock.dca_contract_address.clone(),
-            &ExecuteMsg::CreateVault {
-                owner: None,
-                minimum_receive_amount: None,
-                label: Some("label".to_string()),
-                destinations: None,
-                pool_id: 0,
-                position_type: None,
-                slippage_tolerance: None,
-                swap_amount,
-                time_interval: TimeInterval::Hourly,
-                target_start_time_utc_seconds: None,
-                target_receive_amount: None,
-                use_dca_plus: None,
-            },
-            &vec![Coin::new(vault_deposit.into(), DENOM_UOSMO)],
-        )
-        .unwrap();
-
-    assert_address_balances(
-        &mock,
-        &[
-            (&user_address, DENOM_UOSMO, user_balance - vault_deposit),
-            (&user_address, DENOM_STAKE, Uint128::zero()),
-            (
-                &mock.dca_contract_address,
-                DENOM_UOSMO,
-                ONE_THOUSAND + vault_deposit,
-            ),
-            (&mock.dca_contract_address, DENOM_STAKE, ONE_THOUSAND),
-            (&mock.fin_contract_address, DENOM_UOSMO, ONE_THOUSAND),
-            (&mock.fin_contract_address, DENOM_STAKE, ONE_THOUSAND),
-        ],
-    );
-}
-
-#[test]
-fn with_immediate_time_trigger_and_slippage_failure_should_update_vault_balance() {
-    let user_address = Addr::unchecked(USER);
-    let user_balance = TEN;
-    let vault_deposit = TEN;
-    let swap_amount = ONE;
-    let mut mock = MockApp::new(fin_contract_fail_slippage_tolerance()).with_funds_for(
-        &user_address,
-        user_balance,
-        DENOM_UOSMO,
-    );
-
-    mock.app
-        .execute_contract(
-            Addr::unchecked(USER),
-            mock.dca_contract_address.clone(),
-            &ExecuteMsg::CreateVault {
-                owner: None,
-                minimum_receive_amount: None,
-                label: Some("label".to_string()),
-                destinations: None,
-                pool_id: 0,
-                position_type: None,
-                slippage_tolerance: None,
-                swap_amount,
-                time_interval: TimeInterval::Hourly,
-                target_start_time_utc_seconds: None,
-                target_receive_amount: None,
-                use_dca_plus: None,
-            },
-            &vec![Coin::new(vault_deposit.into(), DENOM_UOSMO)],
-        )
-        .unwrap();
-
-    assert_vault_balance(
-        &mock,
-        &mock.dca_contract_address,
-        user_address,
-        Uint128::new(1),
-        vault_deposit,
-    );
-}
-
-#[test]
-fn with_time_trigger_should_create_vault() {
-    let user_address = Addr::unchecked(USER);
-    let user_balance = TEN;
-    let vault_deposit = TEN;
-    let swap_amount = ONE;
-    let mut mock = MockApp::new(fin_contract_unfilled_limit_order()).with_funds_for(
-        &user_address,
-        user_balance,
-        DENOM_UOSMO,
-    );
-
-    let target_start_time = mock.app.block_info().time.plus_seconds(2);
-
-    mock.app
-        .execute_contract(
-            Addr::unchecked(USER),
-            mock.dca_contract_address.clone(),
-            &ExecuteMsg::CreateVault {
-                owner: None,
-                minimum_receive_amount: None,
-                label: Some("label".to_string()),
-                destinations: None,
-                pool_id: 0,
-                position_type: None,
-                slippage_tolerance: None,
-                swap_amount,
-                time_interval: TimeInterval::Hourly,
-                target_start_time_utc_seconds: Some(Uint64::from(target_start_time.seconds())),
-                target_receive_amount: None,
-                use_dca_plus: None,
-            },
-            &vec![Coin::new(vault_deposit.into(), DENOM_UOSMO)],
-        )
-        .unwrap();
-
-    let vault_id = Uint128::new(1);
-
-    let vault_response: VaultResponse = mock
-        .app
-        .wrap()
-        .query_wasm_smart(&mock.dca_contract_address, &QueryMsg::GetVault { vault_id })
-        .unwrap();
-
-    assert_eq!(
-        vault_response.vault,
-        Vault {
-            minimum_receive_amount: None,
-            label: Some("label".to_string()),
-            id: Uint128::new(1),
-            owner: user_address.clone(),
-            destinations: vec![Destination {
-                address: user_address.clone(),
-                allocation: Decimal::percent(100),
-                action: PostExecutionAction::Send
-            }],
-            created_at: mock.app.block_info().time,
-            status: VaultStatus::Scheduled,
-            time_interval: TimeInterval::Hourly,
-            balance: Coin::new(vault_deposit.into(), DENOM_UOSMO.to_string()),
-            slippage_tolerance: None,
-            swap_amount,
-            pool: Pool {
-                pool_id: 0,
-                base_denom: DENOM_STAKE.to_string(),
-                quote_denom: DENOM_UOSMO.to_string(),
-            },
-            started_at: None,
-            swapped_amount: Coin::new(0, DENOM_UOSMO.to_string()),
-            received_amount: Coin::new(0, DENOM_STAKE.to_string()),
-            trigger: Some(TriggerConfiguration::Time {
-                target_time: target_start_time.minus_nanos(target_start_time.subsec_nanos()),
-            }),
-            dca_plus_config: None,
-        }
-    );
-}
-
-#[test]
-fn with_time_trigger_should_update_address_balances() {
-    let user_address = Addr::unchecked(USER);
-    let user_balance = TEN;
-    let vault_deposit = TEN;
-    let swap_amount = ONE;
-    let mut mock = MockApp::new(fin_contract_unfilled_limit_order()).with_funds_for(
-        &user_address,
-        user_balance,
-        DENOM_UOSMO,
-    );
-
-    assert_address_balances(
-        &mock,
-        &[
-            (&user_address, DENOM_UOSMO, user_balance),
-            (&user_address, DENOM_STAKE, Uint128::new(0)),
-            (&mock.dca_contract_address, DENOM_UOSMO, ONE_THOUSAND),
-            (&mock.dca_contract_address, DENOM_STAKE, ONE_THOUSAND),
-            (&mock.fin_contract_address, DENOM_UOSMO, ONE_THOUSAND),
-            (&mock.fin_contract_address, DENOM_STAKE, ONE_THOUSAND),
-        ],
-    );
-
-    let target_start_time = mock.app.block_info().time.plus_seconds(2);
-
-    mock.app
-        .execute_contract(
-            Addr::unchecked(USER),
-            mock.dca_contract_address.clone(),
-            &ExecuteMsg::CreateVault {
-                owner: None,
-                minimum_receive_amount: None,
-                label: Some("label".to_string()),
-                destinations: None,
-                pool_id: 0,
-                position_type: None,
-                slippage_tolerance: None,
-                swap_amount,
-                time_interval: TimeInterval::Hourly,
-                target_start_time_utc_seconds: Some(Uint64::from(target_start_time.seconds())),
-                target_receive_amount: None,
-                use_dca_plus: None,
-            },
-            &vec![Coin::new(vault_deposit.into(), DENOM_UOSMO)],
-        )
-        .unwrap();
-
-    assert_address_balances(
-        &mock,
-        &[
-            (&user_address, DENOM_UOSMO, user_balance - vault_deposit),
-            (&user_address, DENOM_STAKE, Uint128::new(0)),
-            (
-                &mock.dca_contract_address,
-                DENOM_UOSMO,
-                ONE_THOUSAND + vault_deposit,
-            ),
-            (&mock.dca_contract_address, DENOM_STAKE, ONE_THOUSAND),
-            (&mock.fin_contract_address, DENOM_UOSMO, ONE_THOUSAND),
-            (&mock.fin_contract_address, DENOM_STAKE, ONE_THOUSAND),
-        ],
-    );
-}
-
-#[test]
-fn with_time_trigger_should_publish_vault_created_event() {
-    let user_address = Addr::unchecked(USER);
-    let user_balance = TEN;
-    let vault_deposit = TEN;
-    let swap_amount = ONE;
-    let mut mock = MockApp::new(fin_contract_unfilled_limit_order()).with_funds_for(
-        &user_address,
-        user_balance,
-        DENOM_UOSMO,
-    );
-
-    mock.app
-        .execute_contract(
-            Addr::unchecked(USER),
-            mock.dca_contract_address.clone(),
-            &ExecuteMsg::CreateVault {
-                owner: None,
-                minimum_receive_amount: None,
-                label: Some("label".to_string()),
-                destinations: None,
-                pool_id: 0,
-                position_type: None,
-                slippage_tolerance: None,
-                swap_amount,
-                time_interval: TimeInterval::Hourly,
-                target_start_time_utc_seconds: None,
-                target_receive_amount: None,
-                use_dca_plus: None,
-            },
-            &vec![Coin::new(vault_deposit.into(), DENOM_UOSMO)],
-        )
-        .unwrap();
-
-    let vault_id = Uint128::new(1);
-
-    assert_events_published(
-        &mock,
-        vault_id,
-        &[EventBuilder::new(
-            vault_id,
-            mock.app.block_info(),
-            EventData::DcaVaultCreated {},
-        )
-        .build(1)],
-    );
-}
-
-#[test]
-fn with_time_trigger_should_publish_funds_deposited_event() {
-    let user_address = Addr::unchecked(USER);
-    let user_balance = TEN;
-    let vault_deposit = TEN;
-    let swap_amount = ONE;
-    let mut mock = MockApp::new(fin_contract_unfilled_limit_order()).with_funds_for(
-        &user_address,
-        user_balance,
-        DENOM_UOSMO,
-    );
-
-    mock.app
-        .execute_contract(
-            Addr::unchecked(USER),
-            mock.dca_contract_address.clone(),
-            &ExecuteMsg::CreateVault {
-                owner: None,
-                minimum_receive_amount: None,
-                label: Some("label".to_string()),
-                destinations: None,
-                pool_id: 0,
-                position_type: None,
-                slippage_tolerance: None,
-                swap_amount,
-                time_interval: TimeInterval::Hourly,
-                target_start_time_utc_seconds: None,
-                target_receive_amount: None,
-                use_dca_plus: None,
-            },
-            &vec![Coin::new(vault_deposit.into(), DENOM_UOSMO)],
-        )
-        .unwrap();
-
-    let vault_id = Uint128::new(1);
-
-    assert_events_published(
-        &mock,
-        vault_id,
-        &[EventBuilder::new(
-            vault_id,
-            mock.app.block_info(),
-            EventData::DcaVaultFundsDeposited {
-                amount: Coin::new(vault_deposit.into(), DENOM_UOSMO),
-            },
-        )
-        .build(2)],
-    );
-}
-
-#[test]
-fn with_time_trigger_with_existing_vault_should_create_vault() {
-    let user_address = Addr::unchecked(USER);
-    let user_balance = TEN * Uint128::new(2);
-    let vault_deposit = TEN;
-    let swap_amount = ONE;
-    let mut mock = MockApp::new(fin_contract_unfilled_limit_order())
-        .with_funds_for(&user_address, user_balance, DENOM_UOSMO)
-        .with_vault_with_time_trigger(
-            &user_address,
-            None,
-            Coin::new(vault_deposit.into(), DENOM_UOSMO),
-            swap_amount,
-            "time",
-            None,
-            None,
-        );
-
-    let target_start_time = mock.app.block_info().time.plus_seconds(2);
-
-    let response = mock
-        .app
-        .execute_contract(
-            Addr::unchecked(USER),
-            mock.dca_contract_address.clone(),
-            &ExecuteMsg::CreateVault {
-                owner: None,
-                minimum_receive_amount: None,
-                label: Some("label".to_string()),
-                destinations: None,
-                pool_id: 0,
-                position_type: None,
-                slippage_tolerance: None,
-                swap_amount,
-                time_interval: TimeInterval::Hourly,
-                target_start_time_utc_seconds: Some(Uint64::from(target_start_time.seconds())),
-                target_receive_amount: None,
-                use_dca_plus: None,
-            },
-            &vec![Coin::new(vault_deposit.into(), DENOM_UOSMO)],
-        )
-        .unwrap();
-
-    let vault_id = Uint128::from_str(
-        &get_flat_map_for_event_type(&response.events, "wasm").unwrap()["vault_id"],
+    create_pool(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        0,
+        DENOM_STAKE.to_string(),
+        DENOM_UOSMO.to_string(),
     )
     .unwrap();
 
-    let vault_response: VaultResponse = mock
-        .app
-        .wrap()
-        .query_wasm_smart(&mock.dca_contract_address, &QueryMsg::GetVault { vault_id })
-        .unwrap();
+    let swap_amount = Uint128::new(100000);
+    info = mock_info(USER, &[Coin::new(100000, DENOM_STAKE)]);
+
+    create_vault(
+        deps.as_mut(),
+        env.clone(),
+        &info,
+        info.sender.clone(),
+        None,
+        vec![],
+        0,
+        None,
+        None,
+        None,
+        swap_amount,
+        TimeInterval::Daily,
+        Some(env.block.time.plus_seconds(10).seconds().into()),
+        None,
+        Some(false),
+    )
+    .unwrap();
+
+    let vault = get_vault(deps.as_ref(), Uint128::one()).unwrap().vault;
 
     assert_eq!(
-        vault_response.vault,
+        vault,
         Vault {
             minimum_receive_amount: None,
-            label: Some("label".to_string()),
-            id: Uint128::new(2),
+            label: None,
+            id: Uint128::new(1),
+            owner: info.sender,
             destinations: vec![Destination {
-                address: user_address.clone(),
+                address: Addr::unchecked(USER),
                 allocation: Decimal::percent(100),
                 action: PostExecutionAction::Send
             }],
-            owner: user_address.clone(),
-            created_at: mock.app.block_info().time,
+            created_at: env.block.time,
             status: VaultStatus::Scheduled,
+            time_interval: TimeInterval::Daily,
+            balance: info.funds[0].clone(),
             slippage_tolerance: None,
-            time_interval: TimeInterval::Hourly,
-            balance: Coin::new(vault_deposit.into(), DENOM_UOSMO.to_string()),
             swap_amount,
             pool: Pool {
                 pool_id: 0,
@@ -1059,427 +410,729 @@ fn with_time_trigger_with_existing_vault_should_create_vault() {
                 quote_denom: DENOM_UOSMO.to_string(),
             },
             started_at: None,
-            swapped_amount: Coin::new(0, DENOM_UOSMO.to_string()),
-            received_amount: Coin::new(0, DENOM_STAKE.to_string()),
+            swapped_amount: Coin::new(0, DENOM_STAKE.to_string()),
+            received_amount: Coin::new(0, DENOM_UOSMO.to_string()),
             trigger: Some(TriggerConfiguration::Time {
-                target_time: target_start_time.minus_nanos(target_start_time.subsec_nanos()),
+                target_time: Timestamp::from_seconds(env.block.time.plus_seconds(10).seconds()),
             }),
             dca_plus_config: None,
         }
     );
+}
+
+#[test]
+fn should_publish_vault_created_event() {
+    let mut deps = mock_dependencies();
+    let env = mock_env();
+    let mut info = mock_info(ADMIN, &[]);
+
+    instantiate_contract(deps.as_mut(), env.clone(), info.clone());
+
+    create_pool(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        0,
+        DENOM_STAKE.to_string(),
+        DENOM_UOSMO.to_string(),
+    )
+    .unwrap();
+
+    let swap_amount = Uint128::new(100000);
+    info = mock_info(USER, &[Coin::new(100000, DENOM_STAKE)]);
+
+    create_vault(
+        deps.as_mut(),
+        env.clone(),
+        &info,
+        info.sender.clone(),
+        None,
+        vec![],
+        0,
+        None,
+        None,
+        None,
+        swap_amount,
+        TimeInterval::Daily,
+        Some(env.block.time.plus_seconds(10).seconds().into()),
+        None,
+        Some(false),
+    )
+    .unwrap();
+
+    let events = get_events_by_resource_id(deps.as_ref(), Uint128::one(), None, None)
+        .unwrap()
+        .events;
+
+    assert!(events.contains(
+        &EventBuilder::new(Uint128::one(), env.block, EventData::DcaVaultCreated {}).build(1),
+    ))
+}
+
+#[test]
+fn should_publish_deposit_event() {
+    let mut deps = mock_dependencies();
+    let env = mock_env();
+    let mut info = mock_info(ADMIN, &[]);
+
+    instantiate_contract(deps.as_mut(), env.clone(), info.clone());
+
+    create_pool(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        0,
+        DENOM_STAKE.to_string(),
+        DENOM_UOSMO.to_string(),
+    )
+    .unwrap();
+
+    info = mock_info(USER, &[Coin::new(100000, DENOM_STAKE)]);
+
+    create_vault(
+        deps.as_mut(),
+        env.clone(),
+        &info,
+        info.sender.clone(),
+        None,
+        vec![],
+        0,
+        None,
+        None,
+        None,
+        Uint128::new(100000),
+        TimeInterval::Daily,
+        Some(env.block.time.plus_seconds(10).seconds().into()),
+        None,
+        Some(false),
+    )
+    .unwrap();
+
+    let events = get_events_by_resource_id(deps.as_ref(), Uint128::one(), None, None)
+        .unwrap()
+        .events;
+
+    assert!(events.contains(
+        &EventBuilder::new(
+            Uint128::one(),
+            env.block,
+            EventData::DcaVaultFundsDeposited {
+                amount: info.funds[0].clone()
+            },
+        )
+        .build(2),
+    ))
+}
+
+#[test]
+fn for_different_owner_should_succeed() {
+    let mut deps = mock_dependencies();
+    let env = mock_env();
+    let mut info = mock_info(ADMIN, &[]);
+
+    instantiate_contract(deps.as_mut(), env.clone(), info.clone());
+
+    create_pool(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        0,
+        DENOM_STAKE.to_string(),
+        DENOM_UOSMO.to_string(),
+    )
+    .unwrap();
+
+    let owner = Addr::unchecked(USER);
+    info = mock_info(ADMIN, &[Coin::new(100000, DENOM_STAKE)]);
+
+    create_vault(
+        deps.as_mut(),
+        env.clone(),
+        &info,
+        owner,
+        None,
+        vec![],
+        0,
+        None,
+        None,
+        None,
+        Uint128::new(100000),
+        TimeInterval::Daily,
+        Some(env.block.time.plus_seconds(10).seconds().into()),
+        None,
+        Some(false),
+    )
+    .unwrap();
+
+    let vault = get_vault(deps.as_ref(), Uint128::one()).unwrap().vault;
+
+    assert_eq!(vault.owner, Addr::unchecked(USER));
 }
 
 #[test]
 fn with_multiple_destinations_should_succeed() {
-    let user_address = Addr::unchecked(USER);
-    let user_balance = TEN;
-    let vault_deposit = TEN;
-    let swap_amount = ONE;
-    let mut mock = MockApp::new(fin_contract_unfilled_limit_order()).with_funds_for(
-        &user_address,
-        user_balance,
-        DENOM_UOSMO,
-    );
+    let mut deps = mock_dependencies();
+    let env = mock_env();
+    let mut info = mock_info(ADMIN, &[]);
 
-    let mut destinations = vec![];
+    instantiate_contract(deps.as_mut(), env.clone(), info.clone());
 
-    for _ in 0..5 {
-        destinations.push(Destination {
-            address: Addr::unchecked(USER),
-            allocation: Decimal::percent(20),
+    create_pool(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        0,
+        DENOM_STAKE.to_string(),
+        DENOM_UOSMO.to_string(),
+    )
+    .unwrap();
+
+    info = mock_info(USER, &[Coin::new(100000, DENOM_STAKE)]);
+
+    let destinations = vec![
+        Destination {
+            address: Addr::unchecked("dest-1"),
+            allocation: Decimal::percent(50),
             action: PostExecutionAction::Send,
-        });
-    }
+        },
+        Destination {
+            address: Addr::unchecked("dest-2"),
+            allocation: Decimal::percent(50),
+            action: PostExecutionAction::ZDelegate,
+        },
+    ];
 
-    mock.app
-        .execute_contract(
-            Addr::unchecked(USER),
-            mock.dca_contract_address.clone(),
-            &ExecuteMsg::CreateVault {
-                owner: None,
-                minimum_receive_amount: None,
-                label: Some("label".to_string()),
-                destinations: Some(destinations.clone()),
-                pool_id: 0,
-                position_type: None,
-                slippage_tolerance: None,
-                swap_amount,
-                time_interval: TimeInterval::Hourly,
-                target_start_time_utc_seconds: Some(
-                    (mock.app.block_info().time.seconds() + 10).into(),
-                ),
-                target_receive_amount: None,
-                use_dca_plus: None,
-            },
-            &vec![Coin::new(vault_deposit.into(), DENOM_UOSMO)],
-        )
-        .unwrap();
+    create_vault(
+        deps.as_mut(),
+        env.clone(),
+        &info,
+        info.sender.clone(),
+        None,
+        destinations.clone(),
+        0,
+        None,
+        None,
+        None,
+        Uint128::new(100000),
+        TimeInterval::Daily,
+        Some(env.block.time.plus_seconds(10).seconds().into()),
+        None,
+        Some(false),
+    )
+    .unwrap();
 
-    let vault_id = Uint128::new(1);
+    let vault = get_vault(deps.as_ref(), Uint128::one()).unwrap().vault;
 
-    let vault_response: VaultResponse = mock
-        .app
-        .wrap()
-        .query_wasm_smart(&mock.dca_contract_address, &QueryMsg::GetVault { vault_id })
-        .unwrap();
-
-    assert_eq!(
-        vault_response.vault,
-        Vault {
-            minimum_receive_amount: None,
-            label: Some("label".to_string()),
-            id: Uint128::new(1),
-            owner: user_address.clone(),
-            destinations,
-            created_at: mock.app.block_info().time,
-            status: VaultStatus::Scheduled,
-            time_interval: TimeInterval::Hourly,
-            balance: Coin::new(vault_deposit.into(), DENOM_UOSMO.to_string()),
-            slippage_tolerance: None,
-            swap_amount,
-            pool: Pool {
-                pool_id: 0,
-                base_denom: DENOM_STAKE.to_string(),
-                quote_denom: DENOM_UOSMO.to_string(),
-            },
-            started_at: None,
-            swapped_amount: Coin::new(0, DENOM_UOSMO.to_string()),
-            received_amount: Coin::new(0, DENOM_STAKE.to_string()),
-            trigger: Some(TriggerConfiguration::Time {
-                target_time: mock
-                    .app
-                    .block_info()
-                    .time
-                    .plus_seconds(10)
-                    .minus_nanos(mock.app.block_info().time.subsec_nanos())
-            }),
-            dca_plus_config: None,
-        }
-    );
-}
-
-#[test]
-fn with_passed_in_owner_should_succeed() {
-    let user_address = Addr::unchecked(USER);
-    let user_balance = TEN;
-    let vault_deposit = TEN;
-    let swap_amount = ONE;
-    let mut mock = MockApp::new(fin_contract_unfilled_limit_order()).with_funds_for(
-        &user_address,
-        user_balance,
-        DENOM_UOSMO,
-    );
-
-    let owner = Addr::unchecked("custom-owner");
-
-    mock.app
-        .execute_contract(
-            Addr::unchecked(USER),
-            mock.dca_contract_address.clone(),
-            &ExecuteMsg::CreateVault {
-                owner: Some(owner.clone()),
-                minimum_receive_amount: None,
-                label: Some("label".to_string()),
-                destinations: None,
-                pool_id: 0,
-                position_type: None,
-                slippage_tolerance: None,
-                swap_amount,
-                time_interval: TimeInterval::Hourly,
-                target_receive_amount: Some(swap_amount),
-                target_start_time_utc_seconds: None,
-                use_dca_plus: None,
-            },
-            &vec![Coin::new(vault_deposit.into(), String::from(DENOM_UOSMO))],
-        )
-        .unwrap();
-
-    let vault_response: VaultResponse = mock
-        .app
-        .wrap()
-        .query_wasm_smart(
-            &mock.dca_contract_address,
-            &QueryMsg::GetVault {
-                vault_id: Uint128::new(1),
-            },
-        )
-        .unwrap();
-
-    assert_eq!(vault_response.vault.owner, owner);
-    assert_eq!(vault_response.vault.destinations.len(), 1);
-    assert_eq!(
-        vault_response.vault.destinations.first().unwrap().address,
-        owner
-    );
+    assert_eq!(vault.destinations, destinations);
 }
 
 #[test]
 fn with_insufficient_funds_should_create_inactive_vault() {
-    let user_address = Addr::unchecked(USER);
-    let user_balance = TEN;
-    let vault_deposit = Uint128::one();
-    let swap_amount = ONE;
-    let mut mock = MockApp::new(fin_contract_unfilled_limit_order()).with_funds_for(
-        &user_address,
-        user_balance,
-        DENOM_UOSMO,
-    );
+    let mut deps = mock_dependencies();
+    let env = mock_env();
+    let mut info = mock_info(ADMIN, &[]);
 
-    let target_start_time = mock.app.block_info().time.plus_seconds(2);
+    instantiate_contract(deps.as_mut(), env.clone(), info.clone());
 
-    mock.app
-        .execute_contract(
-            Addr::unchecked(USER),
-            mock.dca_contract_address.clone(),
-            &ExecuteMsg::CreateVault {
-                owner: None,
-                minimum_receive_amount: None,
-                label: Some("label".to_string()),
-                destinations: None,
-                pool_id: 0,
-                position_type: None,
-                slippage_tolerance: None,
-                swap_amount,
-                time_interval: TimeInterval::Hourly,
-                target_start_time_utc_seconds: Some(Uint64::from(target_start_time.seconds())),
-                target_receive_amount: None,
-                use_dca_plus: None,
-            },
-            &vec![Coin::new(vault_deposit.into(), DENOM_UOSMO)],
-        )
-        .unwrap();
+    create_pool(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        0,
+        DENOM_STAKE.to_string(),
+        DENOM_UOSMO.to_string(),
+    )
+    .unwrap();
 
-    let vault_id = Uint128::new(1);
+    info = mock_info(USER, &[Coin::new(1, DENOM_STAKE)]);
 
-    let vault_response: VaultResponse = mock
-        .app
-        .wrap()
-        .query_wasm_smart(&mock.dca_contract_address, &QueryMsg::GetVault { vault_id })
-        .unwrap();
+    create_vault(
+        deps.as_mut(),
+        env.clone(),
+        &info,
+        info.sender.clone(),
+        None,
+        vec![],
+        0,
+        None,
+        None,
+        None,
+        Uint128::new(100000),
+        TimeInterval::Daily,
+        Some(env.block.time.plus_seconds(10).seconds().into()),
+        None,
+        Some(false),
+    )
+    .unwrap();
 
-    assert_eq!(
-        vault_response.vault,
-        Vault {
-            minimum_receive_amount: None,
-            label: Some("label".to_string()),
-            id: Uint128::new(1),
-            owner: user_address.clone(),
-            destinations: vec![Destination {
-                address: user_address.clone(),
-                allocation: Decimal::percent(100),
-                action: PostExecutionAction::Send
-            }],
-            created_at: mock.app.block_info().time,
-            status: VaultStatus::Inactive,
-            time_interval: TimeInterval::Hourly,
-            balance: Coin::new(vault_deposit.into(), DENOM_UOSMO.to_string()),
-            slippage_tolerance: None,
-            swap_amount,
-            pool: Pool {
-                pool_id: 0,
-                base_denom: DENOM_STAKE.to_string(),
-                quote_denom: DENOM_UOSMO.to_string(),
-            },
-            started_at: None,
-            swapped_amount: Coin::new(0, DENOM_UOSMO.to_string()),
-            received_amount: Coin::new(0, DENOM_STAKE.to_string()),
-            trigger: None,
-            dca_plus_config: None,
-        }
-    );
+    let vault = get_vault(deps.as_ref(), Uint128::one()).unwrap().vault;
+
+    assert_eq!(vault.status, VaultStatus::Inactive);
 }
 
 #[test]
 fn with_use_dca_plus_true_should_create_dca_plus_config() {
-    let user_address = Addr::unchecked(USER);
-    let user_balance = TEN;
-    let vault_deposit = TEN;
-    let swap_amount = ONE;
-    let mut mock = MockApp::new(fin_contract_unfilled_limit_order()).with_funds_for(
-        &user_address,
-        user_balance,
-        DENOM_UOSMO,
-    );
+    let mut deps = mock_dependencies();
+    let env = mock_env();
+    let mut info = mock_info(ADMIN, &[]);
 
-    assert_address_balances(
-        &mock,
-        &[
-            (&user_address, DENOM_UOSMO, user_balance),
-            (&user_address, DENOM_STAKE, Uint128::new(0)),
-            (&mock.dca_contract_address, DENOM_UOSMO, ONE_THOUSAND),
-            (&mock.dca_contract_address, DENOM_STAKE, ONE_THOUSAND),
-            (&mock.fin_contract_address, DENOM_UOSMO, ONE_THOUSAND),
-            (&mock.fin_contract_address, DENOM_STAKE, ONE_THOUSAND),
-        ],
-    );
+    instantiate_contract(deps.as_mut(), env.clone(), info.clone());
 
-    let create_vault_response = mock
-        .app
-        .execute_contract(
-            Addr::unchecked(USER),
-            mock.dca_contract_address.clone(),
-            &ExecuteMsg::CreateVault {
-                owner: None,
-                minimum_receive_amount: None,
-                label: Some("label".to_string()),
-                destinations: None,
-                pool_id: 0,
-                position_type: None,
-                slippage_tolerance: None,
-                swap_amount,
-                time_interval: TimeInterval::Hourly,
-                target_receive_amount: Some(swap_amount),
-                target_start_time_utc_seconds: None,
-                use_dca_plus: Some(true),
-            },
-            &vec![Coin::new(vault_deposit.into(), String::from(DENOM_UOSMO))],
-        )
-        .unwrap();
-
-    let vault_id = Uint128::from_str(
-        &get_flat_map_for_event_type(&create_vault_response.events, "wasm").unwrap()["vault_id"],
+    create_pool(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        0,
+        DENOM_STAKE.to_string(),
+        DENOM_UOSMO.to_string(),
     )
     .unwrap();
 
-    let vault = mock
-        .app
-        .wrap()
-        .query_wasm_smart::<VaultResponse>(
-            &mock.dca_contract_address,
-            &QueryMsg::GetVault { vault_id },
-        )
-        .unwrap()
-        .vault;
+    info = mock_info(USER, &[Coin::new(100000, DENOM_STAKE)]);
+
+    create_vault(
+        deps.as_mut(),
+        env.clone(),
+        &info,
+        info.sender.clone(),
+        None,
+        vec![],
+        0,
+        None,
+        None,
+        None,
+        Uint128::new(100000),
+        TimeInterval::Daily,
+        Some(env.block.time.plus_seconds(10).seconds().into()),
+        None,
+        Some(true),
+    )
+    .unwrap();
+
+    let config = get_config(deps.as_ref().storage).unwrap();
+    let vault = get_vault(deps.as_ref(), Uint128::one()).unwrap().vault;
 
     assert_eq!(
         vault.dca_plus_config,
-        Some(DcaPlusConfig::new(
-            Decimal::percent(5),
-            30,
-            Coin::new(vault_deposit.into(), vault.get_swap_denom(),),
-            vault.get_receive_denom()
-        ))
+        Some(DcaPlusConfig {
+            escrow_level: config.dca_plus_escrow_level,
+            model_id: 30,
+            total_deposit: info.funds[0].clone(),
+            standard_dca_swapped_amount: Coin::new(0, vault.balance.denom),
+            standard_dca_received_amount: Coin::new(0, DENOM_UOSMO),
+            escrowed_balance: Coin::new(0, DENOM_UOSMO)
+        })
     );
 }
 
 #[test]
 fn with_large_deposit_should_select_longer_duration_model() {
-    let user_address = Addr::unchecked(USER);
-    let user_balance = TEN;
-    let vault_deposit = TEN;
-    let swap_amount = ONE / Uint128::new(10);
-    let mut mock = MockApp::new(fin_contract_unfilled_limit_order()).with_funds_for(
-        &user_address,
-        user_balance,
-        DENOM_UOSMO,
-    );
+    let mut deps = mock_dependencies();
+    let env = mock_env();
+    let mut info = mock_info(ADMIN, &[]);
 
-    assert_address_balances(
-        &mock,
-        &[
-            (&user_address, DENOM_UOSMO, user_balance),
-            (&user_address, DENOM_STAKE, Uint128::new(0)),
-            (&mock.dca_contract_address, DENOM_UOSMO, ONE_THOUSAND),
-            (&mock.dca_contract_address, DENOM_STAKE, ONE_THOUSAND),
-            (&mock.fin_contract_address, DENOM_UOSMO, ONE_THOUSAND),
-            (&mock.fin_contract_address, DENOM_STAKE, ONE_THOUSAND),
-        ],
-    );
+    instantiate_contract(deps.as_mut(), env.clone(), info.clone());
 
-    let create_vault_response = mock
-        .app
-        .execute_contract(
-            Addr::unchecked(USER),
-            mock.dca_contract_address.clone(),
-            &ExecuteMsg::CreateVault {
-                owner: None,
-                minimum_receive_amount: None,
-                label: Some("label".to_string()),
-                destinations: None,
-                pool_id: 0,
-                position_type: None,
-                slippage_tolerance: None,
-                swap_amount,
-                time_interval: TimeInterval::Daily,
-                target_receive_amount: Some(swap_amount),
-                target_start_time_utc_seconds: None,
-                use_dca_plus: Some(true),
-            },
-            &vec![Coin::new(vault_deposit.into(), String::from(DENOM_UOSMO))],
-        )
-        .unwrap();
-
-    let vault_id = Uint128::from_str(
-        &get_flat_map_for_event_type(&create_vault_response.events, "wasm").unwrap()["vault_id"],
+    create_pool(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        0,
+        DENOM_STAKE.to_string(),
+        DENOM_UOSMO.to_string(),
     )
     .unwrap();
 
-    let vault_response: VaultResponse = mock
-        .app
-        .wrap()
-        .query_wasm_smart(&mock.dca_contract_address, &QueryMsg::GetVault { vault_id })
-        .unwrap();
+    info = mock_info(USER, &[Coin::new(1000000000, DENOM_STAKE)]);
 
-    assert_eq!(vault_response.vault.dca_plus_config.unwrap().model_id, 80);
+    create_vault(
+        deps.as_mut(),
+        env.clone(),
+        &info,
+        info.sender.clone(),
+        None,
+        vec![],
+        0,
+        None,
+        None,
+        None,
+        Uint128::new(100000),
+        TimeInterval::Daily,
+        Some(env.block.time.plus_seconds(10).seconds().into()),
+        None,
+        Some(true),
+    )
+    .unwrap();
+
+    let vault = get_vault(deps.as_ref(), Uint128::one()).unwrap().vault;
+
+    assert_eq!(vault.dca_plus_config.unwrap().model_id, 90);
 }
 
 #[test]
-fn with_small_deposit_should_select_shorter_duration_model() {
-    let user_address = Addr::unchecked(USER);
-    let user_balance = TEN;
-    let vault_deposit = ONE;
-    let swap_amount = TEN;
-    let mut mock = MockApp::new(fin_contract_unfilled_limit_order()).with_funds_for(
-        &user_address,
-        user_balance,
-        DENOM_UOSMO,
-    );
+fn with_no_target_time_should_execute_vault() {
+    let mut deps = mock_dependencies();
+    let env = mock_env();
+    let mut info = mock_info(ADMIN, &[]);
 
-    assert_address_balances(
-        &mock,
-        &[
-            (&user_address, DENOM_UOSMO, user_balance),
-            (&user_address, DENOM_STAKE, Uint128::new(0)),
-            (&mock.dca_contract_address, DENOM_UOSMO, ONE_THOUSAND),
-            (&mock.dca_contract_address, DENOM_STAKE, ONE_THOUSAND),
-            (&mock.fin_contract_address, DENOM_UOSMO, ONE_THOUSAND),
-            (&mock.fin_contract_address, DENOM_STAKE, ONE_THOUSAND),
-        ],
-    );
+    instantiate_contract(deps.as_mut(), env.clone(), info.clone());
 
-    let create_vault_response = mock
-        .app
-        .execute_contract(
-            Addr::unchecked(USER),
-            mock.dca_contract_address.clone(),
-            &ExecuteMsg::CreateVault {
-                owner: None,
-                minimum_receive_amount: None,
-                label: Some("label".to_string()),
-                destinations: None,
-                pool_id: 0,
-                position_type: None,
-                slippage_tolerance: None,
-                swap_amount,
-                time_interval: TimeInterval::Daily,
-                target_receive_amount: Some(swap_amount),
-                target_start_time_utc_seconds: None,
-                use_dca_plus: Some(true),
-            },
-            &vec![Coin::new(vault_deposit.into(), String::from(DENOM_UOSMO))],
-        )
-        .unwrap();
-
-    let vault_id = Uint128::from_str(
-        &get_flat_map_for_event_type(&create_vault_response.events, "wasm").unwrap()["vault_id"],
+    create_pool(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        0,
+        DENOM_STAKE.to_string(),
+        DENOM_UOSMO.to_string(),
     )
     .unwrap();
 
-    let vault_response: VaultResponse = mock
-        .app
-        .wrap()
-        .query_wasm_smart(&mock.dca_contract_address, &QueryMsg::GetVault { vault_id })
-        .unwrap();
+    info = mock_info(USER, &[Coin::new(100000, DENOM_STAKE)]);
 
-    assert_eq!(vault_response.vault.dca_plus_config.unwrap().model_id, 30);
+    let response = create_vault(
+        deps.as_mut(),
+        env.clone(),
+        &info,
+        info.sender.clone(),
+        None,
+        vec![],
+        0,
+        None,
+        None,
+        None,
+        Uint128::new(100000),
+        TimeInterval::Daily,
+        None,
+        None,
+        Some(true),
+    )
+    .unwrap();
+
+    assert!(response
+        .messages
+        .contains(&SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
+            contract_addr: env.contract.address.to_string(),
+            funds: vec![],
+            msg: to_binary(&ExecuteMsg::ExecuteTrigger {
+                trigger_id: Uint128::one()
+            })
+            .unwrap()
+        }))));
 }
+
+// #[test]
+// fn with_immediate_time_trigger_should_update_vault_balance() {
+//     let user_address = Addr::unchecked(USER);
+//     let user_balance = TEN;
+//     let vault_deposit = TEN;
+//     let swap_amount = ONE;
+//     let mut mock = MockApp::new(fin_contract_pass_slippage_tolerance()).with_funds_for(
+//         &user_address,
+//         user_balance,
+//         DENOM_UOSMO,
+//     );
+
+//     mock.app
+//         .execute_contract(
+//             Addr::unchecked(USER),
+//             mock.dca_contract_address.clone(),
+//             &ExecuteMsg::CreateVault {
+//                 owner: None,
+//                 minimum_receive_amount: None,
+//                 label: Some("label".to_string()),
+//                 destinations: None,
+//                 pool_id: 0,
+//                 position_type: None,
+//                 slippage_tolerance: None,
+//                 swap_amount,
+//                 time_interval: TimeInterval::Hourly,
+//                 target_start_time_utc_seconds: None,
+//                 target_receive_amount: None,
+//                 use_dca_plus: None,
+//             },
+//             &vec![Coin::new(vault_deposit.into(), DENOM_UOSMO)],
+//         )
+//         .unwrap();
+
+//     assert_vault_balance(
+//         &mock,
+//         &mock.dca_contract_address,
+//         user_address,
+//         Uint128::new(1),
+//         vault_deposit - swap_amount,
+//     );
+// }
+
+// #[test]
+// fn with_immediate_time_trigger_should_create_active_vault() {
+//     let user_address = Addr::unchecked(USER);
+//     let user_balance = TEN;
+//     let vault_deposit = TEN;
+//     let swap_amount = ONE;
+//     let mut mock = MockApp::new(fin_contract_pass_slippage_tolerance()).with_funds_for(
+//         &user_address,
+//         user_balance,
+//         DENOM_UOSMO,
+//     );
+
+//     mock.app
+//         .execute_contract(
+//             Addr::unchecked(USER),
+//             mock.dca_contract_address.clone(),
+//             &ExecuteMsg::CreateVault {
+//                 owner: None,
+//                 minimum_receive_amount: None,
+//                 label: Some("label".to_string()),
+//                 destinations: None,
+//                 pool_id: 0,
+//                 position_type: None,
+//                 slippage_tolerance: None,
+//                 swap_amount,
+//                 time_interval: TimeInterval::Hourly,
+//                 target_start_time_utc_seconds: None,
+//                 target_receive_amount: None,
+//                 use_dca_plus: None,
+//             },
+//             &vec![Coin::new(vault_deposit.into(), DENOM_UOSMO)],
+//         )
+//         .unwrap();
+
+//     let vault_id = Uint128::new(1);
+
+//     let vault_response: VaultResponse = mock
+//         .app
+//         .wrap()
+//         .query_wasm_smart(&mock.dca_contract_address, &QueryMsg::GetVault { vault_id })
+//         .unwrap();
+
+//     assert_eq!(
+//         vault_response.vault,
+//         Vault {
+//             minimum_receive_amount: None,
+//             label: Some("label".to_string()),
+//             id: vault_id,
+//             owner: user_address.clone(),
+//             destinations: vec![Destination {
+//                 address: user_address.clone(),
+//                 allocation: Decimal::percent(100),
+//                 action: PostExecutionAction::Send
+//             }],
+//             created_at: mock.app.block_info().time,
+//             status: VaultStatus::Active,
+//             time_interval: TimeInterval::Hourly,
+//             balance: Coin::new(
+//                 (vault_deposit - swap_amount).into(),
+//                 DENOM_UOSMO.to_string()
+//             ),
+//             slippage_tolerance: None,
+//             swap_amount,
+//             pool: Pool {
+//                 pool_id: 0,
+//                 base_denom: DENOM_STAKE.to_string(),
+//                 quote_denom: DENOM_UOSMO.to_string(),
+//             },
+//             started_at: Some(mock.app.block_info().time),
+//             swapped_amount: Coin::new(swap_amount.into(), DENOM_UOSMO.to_string()),
+//             received_amount: Coin::new(
+//                 (swap_amount - checked_mul(swap_amount, mock.fee_percent).ok().unwrap()).into(),
+//                 DENOM_STAKE.to_string()
+//             ),
+//             trigger: Some(TriggerConfiguration::Time {
+//                 target_time: mock
+//                     .app
+//                     .block_info()
+//                     .time
+//                     .plus_seconds(60 * 60)
+//                     .minus_nanos(mock.app.block_info().time.subsec_nanos()),
+//             }),
+//             dca_plus_config: None,
+//         }
+//     );
+// }
+
+// #[test]
+// fn with_immediate_time_trigger_should_publish_events() {
+//     let user_address = Addr::unchecked(USER);
+//     let user_balance = TEN;
+//     let vault_deposit = TEN;
+//     let swap_amount = ONE;
+//     let mut mock = MockApp::new(fin_contract_pass_slippage_tolerance()).with_funds_for(
+//         &user_address,
+//         user_balance,
+//         DENOM_UOSMO,
+//     );
+
+//     mock.app
+//         .execute_contract(
+//             Addr::unchecked(USER),
+//             mock.dca_contract_address.clone(),
+//             &ExecuteMsg::CreateVault {
+//                 owner: None,
+//                 minimum_receive_amount: None,
+//                 label: Some("label".to_string()),
+//                 destinations: None,
+//                 pool_id: 0,
+//                 position_type: None,
+//                 slippage_tolerance: None,
+//                 swap_amount,
+//                 time_interval: TimeInterval::Hourly,
+//                 target_start_time_utc_seconds: None,
+//                 target_receive_amount: None,
+//                 use_dca_plus: None,
+//             },
+//             &vec![Coin::new(vault_deposit.into(), DENOM_UOSMO)],
+//         )
+//         .unwrap();
+
+//     let vault_id = Uint128::new(1);
+
+//     assert_events_published(
+//         &mock,
+//         vault_id,
+//         &[
+//             EventBuilder::new(
+//                 vault_id,
+//                 mock.app.block_info(),
+//                 EventData::DcaVaultCreated {},
+//             )
+//             .build(1),
+//             EventBuilder::new(
+//                 vault_id,
+//                 mock.app.block_info(),
+//                 EventData::DcaVaultFundsDeposited {
+//                     amount: Coin::new(vault_deposit.into(), DENOM_UOSMO),
+//                 },
+//             )
+//             .build(2),
+//             EventBuilder::new(
+//                 vault_id,
+//                 mock.app.block_info(),
+//                 EventData::DcaVaultExecutionTriggered {
+//                     base_denom: DENOM_STAKE.to_string(),
+//                     quote_denom: DENOM_UOSMO.to_string(),
+//                     asset_price: Decimal::from_str("1.0").unwrap(),
+//                 },
+//             )
+//             .build(3),
+//             EventBuilder::new(
+//                 vault_id,
+//                 mock.app.block_info(),
+//                 EventData::DcaVaultExecutionCompleted {
+//                     sent: Coin::new(swap_amount.into(), DENOM_UOSMO),
+//                     received: Coin::new(swap_amount.into(), DENOM_STAKE),
+//                     fee: Coin::new(
+//                         (checked_mul(swap_amount, mock.fee_percent).ok().unwrap()).into(),
+//                         DENOM_STAKE,
+//                     ),
+//                 },
+//             )
+//             .build(4),
+//         ],
+//     );
+// }
+
+// #[test]
+// fn with_immediate_time_trigger_and_slippage_failure_should_update_address_balances() {
+//     let user_address = Addr::unchecked(USER);
+//     let user_balance = TEN;
+//     let vault_deposit = TEN;
+//     let swap_amount = ONE;
+//     let mut mock = MockApp::new(fin_contract_fail_slippage_tolerance()).with_funds_for(
+//         &user_address,
+//         user_balance,
+//         DENOM_UOSMO,
+//     );
+
+//     assert_address_balances(
+//         &mock,
+//         &[
+//             (&user_address, DENOM_UOSMO, user_balance),
+//             (&user_address, DENOM_STAKE, Uint128::new(0)),
+//             (&mock.dca_contract_address, DENOM_UOSMO, ONE_THOUSAND),
+//             (&mock.dca_contract_address, DENOM_STAKE, ONE_THOUSAND),
+//             (&mock.fin_contract_address, DENOM_UOSMO, ONE_THOUSAND),
+//             (&mock.fin_contract_address, DENOM_STAKE, ONE_THOUSAND),
+//         ],
+//     );
+
+//     mock.app
+//         .execute_contract(
+//             Addr::unchecked(USER),
+//             mock.dca_contract_address.clone(),
+//             &ExecuteMsg::CreateVault {
+//                 owner: None,
+//                 minimum_receive_amount: None,
+//                 label: Some("label".to_string()),
+//                 destinations: None,
+//                 pool_id: 0,
+//                 position_type: None,
+//                 slippage_tolerance: None,
+//                 swap_amount,
+//                 time_interval: TimeInterval::Hourly,
+//                 target_start_time_utc_seconds: None,
+//                 target_receive_amount: None,
+//                 use_dca_plus: None,
+//             },
+//             &vec![Coin::new(vault_deposit.into(), DENOM_UOSMO)],
+//         )
+//         .unwrap();
+
+//     assert_address_balances(
+//         &mock,
+//         &[
+//             (&user_address, DENOM_UOSMO, user_balance - vault_deposit),
+//             (&user_address, DENOM_STAKE, Uint128::zero()),
+//             (
+//                 &mock.dca_contract_address,
+//                 DENOM_UOSMO,
+//                 ONE_THOUSAND + vault_deposit,
+//             ),
+//             (&mock.dca_contract_address, DENOM_STAKE, ONE_THOUSAND),
+//             (&mock.fin_contract_address, DENOM_UOSMO, ONE_THOUSAND),
+//             (&mock.fin_contract_address, DENOM_STAKE, ONE_THOUSAND),
+//         ],
+//     );
+// }
+
+// #[test]
+// fn with_immediate_time_trigger_and_slippage_failure_should_update_vault_balance() {
+//     let user_address = Addr::unchecked(USER);
+//     let user_balance = TEN;
+//     let vault_deposit = TEN;
+//     let swap_amount = ONE;
+//     let mut mock = MockApp::new(fin_contract_fail_slippage_tolerance()).with_funds_for(
+//         &user_address,
+//         user_balance,
+//         DENOM_UOSMO,
+//     );
+
+//     mock.app
+//         .execute_contract(
+//             Addr::unchecked(USER),
+//             mock.dca_contract_address.clone(),
+//             &ExecuteMsg::CreateVault {
+//                 owner: None,
+//                 minimum_receive_amount: None,
+//                 label: Some("label".to_string()),
+//                 destinations: None,
+//                 pool_id: 0,
+//                 position_type: None,
+//                 slippage_tolerance: None,
+//                 swap_amount,
+//                 time_interval: TimeInterval::Hourly,
+//                 target_start_time_utc_seconds: None,
+//                 target_receive_amount: None,
+//                 use_dca_plus: None,
+//             },
+//             &vec![Coin::new(vault_deposit.into(), DENOM_UOSMO)],
+//         )
+//         .unwrap();
+
+//     assert_vault_balance(
+//         &mock,
+//         &mock.dca_contract_address,
+//         user_address,
+//         Uint128::new(1),
+//         vault_deposit,
+//     );
+// }


### PR DESCRIPTION
@fluffydonkey making a similar change here - calling execute trigger via a message rather than directly allows us to write more tests that do not need to stub the underlying pool manager module