### PR TITLE
restrict update swap adjustment to executors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "autocfg"
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b76d2207945b8aa3ce0735da53ab9a74f75fe3e7794754c216a9edfa04e1e627"
+checksum = "75836a10cb9654c54e77ee56da94d592923092a10b369cdb0dbd56acefc16340"
 dependencies = [
  "digest 0.10.6",
  "ed25519-zebra",
@@ -121,18 +121,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd07af7736164d2d8126dc67fdb33b1b5c54fb5a3190395c47f46d24fc6d592"
+checksum = "1c9f7f0e51bfc7295f7b2664fe8513c966428642aa765dad8a74acdab5e0c773"
 dependencies = [
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9e92cdce475a91659d0dc4d17836a484fc534e80e787281aa4adde4cb1798b"
+checksum = "0f00b363610218eea83f24bbab09e1a7c3920b79f068334fdfcc62f6129ef9fc"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69681bac3dbeb0b00990279e3ed39e3d4406b29f538b16b712f6771322a45048"
+checksum = "ae38f909b2822d32b275c9e2db9728497aa33ffe67dd463bc67c6a3b7092785c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d39f20967baeb94709123f7bba13a25ae2fa166bc5e7813f734914df3f8f6a1"
+checksum = "a49b85345e811c8e80ec55d0d091e4fcb4f00f97ab058f9be5f614c444a730cb"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88f7944b5204c3a998f73248925a097ace887bdf01c2f70de00d8b92cd69e807"
+checksum = "a3737a3aac48f5ed883b5b73bfb731e77feebd8fc6b43419844ec2971072164d"
 dependencies = [
  "cosmwasm-std",
  "serde",

--- a/contracts/dca/schema/dca.json
+++ b/contracts/dca/schema/dca.json
@@ -9,6 +9,7 @@
     "required": [
       "admin",
       "delegation_fee_percent",
+      "executors",
       "fee_collectors",
       "page_limit",
       "paused",
@@ -21,6 +22,12 @@
       },
       "delegation_fee_percent": {
         "$ref": "#/definitions/Decimal"
+      },
+      "executors": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Addr"
+        }
       },
       "fee_collectors": {
         "type": "array",
@@ -335,6 +342,15 @@
                     "type": "null"
                   }
                 ]
+              },
+              "executors": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/definitions/Addr"
+                }
               },
               "fee_collectors": {
                 "type": [
@@ -1131,6 +1147,7 @@
           "required": [
             "admin",
             "delegation_fee_percent",
+            "executors",
             "fee_collectors",
             "page_limit",
             "paused",
@@ -1143,6 +1160,12 @@
             },
             "delegation_fee_percent": {
               "$ref": "#/definitions/Decimal"
+            },
+            "executors": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Addr"
+              }
             },
             "fee_collectors": {
               "type": "array",
@@ -1511,7 +1534,7 @@
               "type": "string",
               "enum": [
                 "slippage_tolerance_exceeded",
-                "unknown_failure"
+                "swap_amount_adjusted_to_zero"
               ]
             },
             {
@@ -1527,37 +1550,6 @@
                   ],
                   "properties": {
                     "price": {
-                      "$ref": "#/definitions/Decimal"
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "required": [
-                "price_delta_limit_exceeded"
-              ],
-              "properties": {
-                "price_delta_limit_exceeded": {
-                  "type": "object",
-                  "required": [
-                    "actual_price_delta",
-                    "duration_in_seconds",
-                    "max_price_delta"
-                  ],
-                  "properties": {
-                    "actual_price_delta": {
-                      "$ref": "#/definitions/Decimal"
-                    },
-                    "duration_in_seconds": {
-                      "type": "integer",
-                      "format": "uint64",
-                      "minimum": 0.0
-                    },
-                    "max_price_delta": {
                       "$ref": "#/definitions/Decimal"
                     }
                   },
@@ -1852,7 +1844,7 @@
               "type": "string",
               "enum": [
                 "slippage_tolerance_exceeded",
-                "unknown_failure"
+                "swap_amount_adjusted_to_zero"
               ]
             },
             {
@@ -1868,37 +1860,6 @@
                   ],
                   "properties": {
                     "price": {
-                      "$ref": "#/definitions/Decimal"
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "required": [
-                "price_delta_limit_exceeded"
-              ],
-              "properties": {
-                "price_delta_limit_exceeded": {
-                  "type": "object",
-                  "required": [
-                    "actual_price_delta",
-                    "duration_in_seconds",
-                    "max_price_delta"
-                  ],
-                  "properties": {
-                    "actual_price_delta": {
-                      "$ref": "#/definitions/Decimal"
-                    },
-                    "duration_in_seconds": {
-                      "type": "integer",
-                      "format": "uint64",
-                      "minimum": 0.0
-                    },
-                    "max_price_delta": {
                       "$ref": "#/definitions/Decimal"
                     }
                   },

--- a/contracts/dca/schema/raw/execute.json
+++ b/contracts/dca/schema/raw/execute.json
@@ -263,6 +263,15 @@
                 }
               ]
             },
+            "executors": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "$ref": "#/definitions/Addr"
+              }
+            },
             "fee_collectors": {
               "type": [
                 "array",

--- a/contracts/dca/schema/raw/instantiate.json
+++ b/contracts/dca/schema/raw/instantiate.json
@@ -5,6 +5,7 @@
   "required": [
     "admin",
     "delegation_fee_percent",
+    "executors",
     "fee_collectors",
     "page_limit",
     "paused",
@@ -17,6 +18,12 @@
     },
     "delegation_fee_percent": {
       "$ref": "#/definitions/Decimal"
+    },
+    "executors": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Addr"
+      }
     },
     "fee_collectors": {
       "type": "array",

--- a/contracts/dca/schema/raw/response_to_get_config.json
+++ b/contracts/dca/schema/raw/response_to_get_config.json
@@ -21,6 +21,7 @@
       "required": [
         "admin",
         "delegation_fee_percent",
+        "executors",
         "fee_collectors",
         "page_limit",
         "paused",
@@ -33,6 +34,12 @@
         },
         "delegation_fee_percent": {
           "$ref": "#/definitions/Decimal"
+        },
+        "executors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Addr"
+          }
         },
         "fee_collectors": {
           "type": "array",

--- a/contracts/dca/schema/raw/response_to_get_events.json
+++ b/contracts/dca/schema/raw/response_to_get_events.json
@@ -264,7 +264,7 @@
           "type": "string",
           "enum": [
             "slippage_tolerance_exceeded",
-            "unknown_failure"
+            "swap_amount_adjusted_to_zero"
           ]
         },
         {
@@ -280,37 +280,6 @@
               ],
               "properties": {
                 "price": {
-                  "$ref": "#/definitions/Decimal"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "price_delta_limit_exceeded"
-          ],
-          "properties": {
-            "price_delta_limit_exceeded": {
-              "type": "object",
-              "required": [
-                "actual_price_delta",
-                "duration_in_seconds",
-                "max_price_delta"
-              ],
-              "properties": {
-                "actual_price_delta": {
-                  "$ref": "#/definitions/Decimal"
-                },
-                "duration_in_seconds": {
-                  "type": "integer",
-                  "format": "uint64",
-                  "minimum": 0.0
-                },
-                "max_price_delta": {
                   "$ref": "#/definitions/Decimal"
                 }
               },

--- a/contracts/dca/schema/raw/response_to_get_events_by_resource_id.json
+++ b/contracts/dca/schema/raw/response_to_get_events_by_resource_id.json
@@ -264,7 +264,7 @@
           "type": "string",
           "enum": [
             "slippage_tolerance_exceeded",
-            "unknown_failure"
+            "swap_amount_adjusted_to_zero"
           ]
         },
         {
@@ -280,37 +280,6 @@
               ],
               "properties": {
                 "price": {
-                  "$ref": "#/definitions/Decimal"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "price_delta_limit_exceeded"
-          ],
-          "properties": {
-            "price_delta_limit_exceeded": {
-              "type": "object",
-              "required": [
-                "actual_price_delta",
-                "duration_in_seconds",
-                "max_price_delta"
-              ],
-              "properties": {
-                "actual_price_delta": {
-                  "$ref": "#/definitions/Decimal"
-                },
-                "duration_in_seconds": {
-                  "type": "integer",
-                  "format": "uint64",
-                  "minimum": 0.0
-                },
-                "max_price_delta": {
                   "$ref": "#/definitions/Decimal"
                 }
               },

--- a/contracts/dca/src/contract.rs
+++ b/contracts/dca/src/contract.rs
@@ -108,6 +108,7 @@ pub fn execute(
             deposit_handler(deps, env, info, address, vault_id)
         }
         ExecuteMsg::UpdateConfig {
+            executors,
             fee_collectors,
             swap_fee_percent,
             delegation_fee_percent,
@@ -117,6 +118,7 @@ pub fn execute(
         } => update_config_handler(
             deps,
             info,
+            executors,
             fee_collectors,
             swap_fee_percent,
             delegation_fee_percent,
@@ -132,7 +134,7 @@ pub fn execute(
             remove_custom_swap_fee_handler(deps, info, denom)
         }
         ExecuteMsg::UpdateSwapAdjustment { strategy, value } => {
-            update_swap_adjustment_handler(deps, env, strategy, value)
+            update_swap_adjustment_handler(deps, env, info, strategy, value)
         }
         ExecuteMsg::DisburseEscrow { vault_id } => {
             disburse_escrow_handler(deps, &env, info, vault_id)

--- a/contracts/dca/src/handlers/create_vault.rs
+++ b/contracts/dca/src/handlers/create_vault.rs
@@ -207,11 +207,12 @@ mod create_vault_tests {
     use crate::handlers::get_events_by_resource_id::get_events_by_resource_id_handler;
     use crate::handlers::get_vault::get_vault_handler;
     use crate::msg::ExecuteMsg;
-    use crate::state::config::{get_config, update_config, Config};
+    use crate::state::config::{get_config, update_config};
     use crate::tests::helpers::instantiate_contract;
     use crate::tests::mocks::{
         calc_mock_dependencies, ADMIN, DENOM_STAKE, DENOM_UOSMO, USER, VALIDATOR,
     };
+    use crate::types::config::Config;
     use crate::types::destination::Destination;
     use crate::types::event::{EventBuilder, EventData};
     use crate::types::pair::Pair;

--- a/contracts/dca/src/handlers/deposit.rs
+++ b/contracts/dca/src/handlers/deposit.rs
@@ -124,9 +124,10 @@ mod dposit_tests {
     use crate::handlers::get_vault::get_vault_handler;
     use crate::helpers::coin::{add, subtract};
     use crate::msg::ExecuteMsg;
-    use crate::state::config::{get_config, update_config, Config};
+    use crate::state::config::{get_config, update_config};
     use crate::tests::helpers::{instantiate_contract, setup_vault};
     use crate::tests::mocks::{ADMIN, DENOM_STAKE, DENOM_UOSMO, USER};
+    use crate::types::config::Config;
     use crate::types::event::{EventBuilder, EventData};
     use crate::types::position_type::PositionType;
     use crate::types::swap_adjustment_strategy::{BaseDenom, SwapAdjustmentStrategy};

--- a/contracts/dca/src/handlers/disburse_escrow.rs
+++ b/contracts/dca/src/handlers/disburse_escrow.rs
@@ -5,7 +5,7 @@ use crate::{
         disbursement::get_disbursement_messages,
         fees::{get_fee_messages, get_performance_fee},
         price::query_belief_price,
-        validation::assert_sender_is_contract_or_admin,
+        validation::assert_sender_is_executor,
     },
     state::{
         disburse_escrow_tasks::delete_disburse_escrow_task,
@@ -26,7 +26,7 @@ pub fn disburse_escrow_handler(
     info: MessageInfo,
     vault_id: Uint128,
 ) -> Result<Response, ContractError> {
-    assert_sender_is_contract_or_admin(deps.storage, &info.sender, env)?;
+    assert_sender_is_executor(deps.storage, env, &info.sender)?;
 
     let vault = get_vault(deps.storage, vault_id)?;
 

--- a/contracts/dca/src/handlers/disburse_funds.rs
+++ b/contracts/dca/src/handlers/disburse_funds.rs
@@ -145,7 +145,7 @@ mod disburse_funds_tests {
         helpers::vault::get_swap_amount,
         state::{
             cache::{SwapCache, SWAP_CACHE},
-            config::{create_custom_fee, get_config, FeeCollector},
+            config::{create_custom_fee, get_config},
             swap_adjustments::update_swap_adjustment,
             vaults::get_vault,
         },
@@ -159,6 +159,7 @@ mod disburse_funds_tests {
         types::{
             destination::Destination,
             event::{Event, EventBuilder, EventData, ExecutionSkippedReason},
+            fee_collector::FeeCollector,
             performance_assessment_strategy::PerformanceAssessmentStrategy,
             position_type::PositionType,
             swap_adjustment_strategy::{BaseDenom, SwapAdjustmentStrategy},

--- a/contracts/dca/src/handlers/execute_trigger.rs
+++ b/contracts/dca/src/handlers/execute_trigger.rs
@@ -223,12 +223,13 @@ mod execute_trigger_tests {
     use crate::helpers::fees::{get_delegation_fee_rate, get_swap_fee_rate};
     use crate::helpers::vault::get_swap_amount;
     use crate::msg::ExecuteMsg;
-    use crate::state::config::{update_config, Config};
+    use crate::state::config::update_config;
     use crate::state::swap_adjustments::update_swap_adjustment;
     use crate::state::triggers::delete_trigger;
     use crate::state::vaults::get_vault;
     use crate::tests::helpers::{instantiate_contract, setup_vault};
     use crate::tests::mocks::{calc_mock_dependencies, ADMIN, DENOM_STAKE, DENOM_UOSMO};
+    use crate::types::config::Config;
     use crate::types::event::{Event, EventData, ExecutionSkippedReason};
     use crate::types::performance_assessment_strategy::PerformanceAssessmentStrategy;
     use crate::types::position_type::PositionType;

--- a/contracts/dca/src/handlers/update_swap_adjustment_handler.rs
+++ b/contracts/dca/src/handlers/update_swap_adjustment_handler.rs
@@ -1,15 +1,18 @@
 use crate::{
-    error::ContractError, state::swap_adjustments::update_swap_adjustment,
+    error::ContractError, helpers::validation::assert_sender_is_executor,
+    state::swap_adjustments::update_swap_adjustment,
     types::swap_adjustment_strategy::SwapAdjustmentStrategy,
 };
-use cosmwasm_std::{Decimal, DepsMut, Env, Response};
+use cosmwasm_std::{Decimal, DepsMut, Env, MessageInfo, Response};
 
 pub fn update_swap_adjustment_handler(
     deps: DepsMut,
     env: Env,
+    info: MessageInfo,
     strategy: SwapAdjustmentStrategy,
     value: Decimal,
 ) -> Result<Response, ContractError> {
+    assert_sender_is_executor(deps.storage, &env, &info.sender)?;
     update_swap_adjustment(deps.storage, strategy, value, env.block.time)?;
     Ok(Response::new())
 }
@@ -19,19 +22,52 @@ mod update_swap_adjustments_tests {
     use super::*;
     use crate::{
         state::swap_adjustments::get_swap_adjustment,
+        tests::{helpers::instantiate_contract, mocks::ADMIN},
         types::{
             position_type::PositionType,
             swap_adjustment_strategy::{BaseDenom, SwapAdjustmentStrategy},
         },
     };
     use cosmwasm_std::{
-        testing::{mock_dependencies, mock_env},
+        testing::{mock_dependencies, mock_env, mock_info},
         Decimal,
     };
 
     #[test]
+    fn with_non_executor_sender_fails() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let info = mock_info(ADMIN, &[]);
+
+        instantiate_contract(deps.as_mut(), env.clone(), info.clone());
+
+        let strategy = SwapAdjustmentStrategy::RiskWeightedAverage {
+            model_id: 30,
+            base_denom: BaseDenom::Bitcoin,
+            position_type: PositionType::Enter,
+        };
+
+        let value = Decimal::percent(125);
+
+        let err = update_swap_adjustment_handler(
+            deps.as_mut(),
+            env.clone(),
+            mock_info("not-an-executor", &[]),
+            strategy.clone(),
+            value,
+        )
+        .unwrap_err();
+
+        assert_eq!(err.to_string(), "Unauthorized");
+    }
+
+    #[test]
     fn updates_swap_adjustment() {
         let mut deps = mock_dependencies();
+        let env = mock_env();
+        let info = mock_info(ADMIN, &[]);
+
+        instantiate_contract(deps.as_mut(), env.clone(), info.clone());
 
         let strategy = SwapAdjustmentStrategy::RiskWeightedAverage {
             model_id: 30,
@@ -40,15 +76,29 @@ mod update_swap_adjustments_tests {
         };
 
         let old_value = Decimal::percent(125);
-        update_swap_adjustment_handler(deps.as_mut(), mock_env(), strategy.clone(), old_value)
-            .unwrap();
+
+        update_swap_adjustment_handler(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            strategy.clone(),
+            old_value,
+        )
+        .unwrap();
 
         let new_value = Decimal::percent(95);
-        update_swap_adjustment_handler(deps.as_mut(), mock_env(), strategy.clone(), new_value)
-            .unwrap();
+
+        update_swap_adjustment_handler(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            strategy.clone(),
+            new_value,
+        )
+        .unwrap();
 
         let stored_adjustment =
-            get_swap_adjustment(deps.as_ref().storage, strategy, mock_env().block.time);
+            get_swap_adjustment(deps.as_ref().storage, strategy, env.block.time);
 
         assert_ne!(stored_adjustment, old_value);
         assert_eq!(stored_adjustment, new_value);

--- a/contracts/dca/src/msg.rs
+++ b/contracts/dca/src/msg.rs
@@ -1,6 +1,7 @@
-use crate::state::config::{Config, FeeCollector};
+use crate::types::config::Config;
 use crate::types::destination::Destination;
 use crate::types::event::Event;
+use crate::types::fee_collector::FeeCollector;
 use crate::types::pair::Pair;
 use crate::types::performance_assessment_strategy::PerformanceAssessmentStrategyParams;
 use crate::types::position_type::PositionType;
@@ -16,6 +17,7 @@ use cosmwasm_std::{Addr, Coin, Decimal, Uint128, Uint64};
 #[cw_serde]
 pub struct InstantiateMsg {
     pub admin: Addr,
+    pub executors: Vec<Addr>,
     pub fee_collectors: Vec<FeeCollector>,
     pub swap_fee_percent: Decimal,
     pub delegation_fee_percent: Decimal,
@@ -63,6 +65,7 @@ pub enum ExecuteMsg {
         trigger_id: Uint128,
     },
     UpdateConfig {
+        executors: Option<Vec<Addr>>,
         fee_collectors: Option<Vec<FeeCollector>>,
         swap_fee_percent: Option<Decimal>,
         delegation_fee_percent: Option<Decimal>,

--- a/contracts/dca/src/state/config.rs
+++ b/contracts/dca/src/state/config.rs
@@ -1,23 +1,6 @@
-use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Decimal, Order, StdError, StdResult, Storage};
+use crate::types::config::Config;
+use cosmwasm_std::{Decimal, Order, StdError, StdResult, Storage};
 use cw_storage_plus::{Item, Map};
-
-#[cw_serde]
-pub struct Config {
-    pub admin: Addr,
-    pub fee_collectors: Vec<FeeCollector>,
-    pub swap_fee_percent: Decimal,
-    pub delegation_fee_percent: Decimal,
-    pub page_limit: u16,
-    pub paused: bool,
-    pub risk_weighted_average_escrow_level: Decimal,
-}
-
-#[cw_serde]
-pub struct FeeCollector {
-    pub address: String,
-    pub allocation: Decimal,
-}
 
 const CONFIG: Item<Config> = Item::new("config_v6");
 

--- a/contracts/dca/src/tests/helpers.rs
+++ b/contracts/dca/src/tests/helpers.rs
@@ -6,14 +6,15 @@ use crate::{
     msg::{ExecuteMsg, InstantiateMsg},
     state::{
         cache::{VaultCache, VAULT_CACHE},
-        config::{Config, FeeCollector},
         pairs::save_pair,
         triggers::save_trigger,
         vaults::update_vault,
     },
     types::{
+        config::Config,
         destination::Destination,
         event::{EventBuilder, EventData},
+        fee_collector::FeeCollector,
         pair::Pair,
         performance_assessment_strategy::PerformanceAssessmentStrategy,
         position_type::PositionType,
@@ -33,6 +34,7 @@ use std::{cmp::max, str::FromStr};
 pub fn instantiate_contract(deps: DepsMut, env: Env, info: MessageInfo) {
     let instantiate_message = InstantiateMsg {
         admin: Addr::unchecked(ADMIN),
+        executors: vec![Addr::unchecked("executor")],
         fee_collectors: vec![FeeCollector {
             address: ADMIN.to_string(),
             allocation: Decimal::from_str("1").unwrap(),
@@ -55,6 +57,7 @@ pub fn instantiate_contract_with_multiple_fee_collectors(
 ) {
     let instantiate_message = InstantiateMsg {
         admin: Addr::unchecked(ADMIN),
+        executors: vec![Addr::unchecked("executor")],
         fee_collectors,
         swap_fee_percent: Decimal::from_str("0.0165").unwrap(),
         delegation_fee_percent: Decimal::from_str("0.0075").unwrap(),
@@ -70,6 +73,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             admin: Addr::unchecked(ADMIN),
+            executors: vec![Addr::unchecked("executor")],
             fee_collectors: vec![FeeCollector {
                 address: ADMIN.to_string(),
                 allocation: Decimal::from_str("1").unwrap(),

--- a/contracts/dca/src/types/config.rs
+++ b/contracts/dca/src/types/config.rs
@@ -1,0 +1,15 @@
+use super::fee_collector::FeeCollector;
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{Addr, Decimal};
+
+#[cw_serde]
+pub struct Config {
+    pub admin: Addr,
+    pub executors: Vec<Addr>,
+    pub fee_collectors: Vec<FeeCollector>,
+    pub swap_fee_percent: Decimal,
+    pub delegation_fee_percent: Decimal,
+    pub page_limit: u16,
+    pub paused: bool,
+    pub risk_weighted_average_escrow_level: Decimal,
+}

--- a/contracts/dca/src/types/fee_collector.rs
+++ b/contracts/dca/src/types/fee_collector.rs
@@ -1,0 +1,8 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::Decimal;
+
+#[cw_serde]
+pub struct FeeCollector {
+    pub address: String,
+    pub allocation: Decimal,
+}

--- a/contracts/dca/src/types/mod.rs
+++ b/contracts/dca/src/types/mod.rs
@@ -1,5 +1,7 @@
+pub mod config;
 pub mod destination;
 pub mod event;
+pub mod fee_collector;
 pub mod pair;
 pub mod performance_assessment_strategy;
 pub mod position_type;


### PR DESCRIPTION
Changes include:
1. Add a list of executors to the contract stored config
2. Check if the sender is in the list or is admin or is the contract when calling disburse escrow and update swap adjustment endpoints