### PR TITLE
use started_at to calculate next execution date

### DIFF
--- a/contracts/dca/src/handlers/execute_trigger.rs
+++ b/contracts/dca/src/handlers/execute_trigger.rs
@@ -123,10 +123,7 @@ pub fn execute_trigger_handler(
                 configuration: TriggerConfiguration::Time {
                     target_time: get_next_target_time(
                         env.block.time,
-                        match vault.trigger {
-                            Some(TriggerConfiguration::Time { target_time }) => target_time,
-                            _ => env.block.time,
-                        },
+                        vault.started_at.unwrap_or(env.block.time),
                         vault.time_interval.clone(),
                     ),
                 },

--- a/contracts/dca/src/helpers/time.rs
+++ b/contracts/dca/src/helpers/time.rs
@@ -9,18 +9,18 @@ pub fn target_time_elapsed(current_time: Timestamp, target_execution_time: Times
 
 pub fn get_next_target_time(
     current_timestamp: Timestamp,
-    last_execution_timestamp: Timestamp,
+    started_at: Timestamp,
     interval: TimeInterval,
 ) -> Timestamp {
     let current_time = Utc
         .timestamp_opt(current_timestamp.seconds().try_into().unwrap(), 0)
         .unwrap();
 
-    let last_execution_time = Utc
-        .timestamp_opt(last_execution_timestamp.seconds().try_into().unwrap(), 0)
+    let started_at_time = Utc
+        .timestamp_opt(started_at.seconds().try_into().unwrap(), 0)
         .unwrap();
 
-    let mut next_execution_time = get_next_time(last_execution_time, &interval);
+    let mut next_execution_time = get_next_time(started_at_time, &interval);
 
     match interval {
         TimeInterval::Monthly => {
@@ -29,18 +29,16 @@ pub fn get_next_target_time(
             }
         }
         _ => {
-            let interval_duration_in_seconds =
-                get_duration(last_execution_time, &interval).num_seconds();
+            let interval_duration = get_duration(started_at_time, &interval);
 
-            let increments_until_future_execution_date = (current_time - last_execution_time)
+            let increments_until_future_execution_date = (current_time - started_at_time)
                 .num_seconds()
-                .checked_div(interval_duration_in_seconds)
+                .checked_div(interval_duration.num_seconds())
                 .expect("should be a valid timestamp")
                 + 1;
 
-            next_execution_time = last_execution_time
-                + get_duration(last_execution_time, &interval)
-                    * increments_until_future_execution_date as i32;
+            next_execution_time =
+                started_at_time + interval_duration * increments_until_future_execution_date as i32;
         }
     }
 

--- a/contracts/dca/src/types/vault.rs
+++ b/contracts/dca/src/types/vault.rs
@@ -20,6 +20,7 @@ pub enum VaultStatus {
 pub struct Vault {
     pub id: Uint128,
     pub created_at: Timestamp,
+    pub started_at: Option<Timestamp>,
     pub owner: Addr,
     pub label: Option<String>,
     pub destinations: Vec<Destination>,
@@ -30,7 +31,6 @@ pub struct Vault {
     pub slippage_tolerance: Option<Decimal>,
     pub minimum_receive_amount: Option<Uint128>,
     pub time_interval: TimeInterval,
-    pub started_at: Option<Timestamp>,
     pub escrow_level: Decimal,
     pub deposited_amount: Coin,
     pub swapped_amount: Coin,
@@ -182,6 +182,7 @@ impl VaultBuilder {
         Vault {
             id,
             created_at: self.created_at,
+            started_at: self.started_at,
             owner: self.owner,
             label: self.label,
             destinations: self.destinations,
@@ -192,7 +193,6 @@ impl VaultBuilder {
             slippage_tolerance: self.slippage_tolerance,
             minimum_receive_amount: self.minimum_receive_amount,
             time_interval: self.time_interval,
-            started_at: self.started_at,
             escrow_level: self.escrow_level,
             deposited_amount: self.deposited_amount,
             swapped_amount: self.swapped_amount,


### PR DESCRIPTION
We want to ensure a vault always executes according to the initial execution time and interval, regardless of whether it has been inactive due to lack of funds, or execution has been delayed due to off-chain scheduler issues. Therefore it makes sense to use the started_at value of the vault to calculate the next execution date.

This update also prevents any issues that arise from vaults that deposit into each other causing recursive executions when they are both "empty".

cc @berndartmueller @philipstanislaus @jcr-oaksec @fluffydonkey