### PR TITLE
fix performance assessment strategy setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "edc207893e85c5d6be840e969b496b53d94cec8be2d501b214f50daa97fa8024"
 
 [[package]]
 name = "num-derive"
@@ -822,9 +822,9 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
 dependencies = [
  "serde_derive",
 ]
@@ -858,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tests/src/tests/dca/create-vault.test.ts
+++ b/tests/src/tests/dca/create-vault.test.ts
@@ -246,7 +246,7 @@ describe('when creating a vault', () => {
     });
   });
 
-  describe('with dca plus & a time trigger', () => {
+  describe('with risk weight average strategy & a time trigger', () => {
     let vault: Vault;
 
     before(async function (this: Context) {
@@ -290,7 +290,7 @@ describe('when creating a vault', () => {
     });
   });
 
-  describe('with dca plus & no trigger', () => {
+  describe('with risk weight average strategy & no trigger', () => {
     const deposit = coin(1000000, 'stake');
     const swapAmount = '100000';
     let vault: Vault;


### PR DESCRIPTION
**Audit Issue No. 3:** `PerformanceAssessmentStrategy::CompareToStandardDca` is incorrectly used for Vaults performance_assessment_strategy when choosing `SwapAdjustmentStrategyParams::WeightedScale`.

**Solution:** Use the provided `performance_assessment_strategy_params` to create & save the appropriate `performance_assessment_strategy` against the vault. This also means the appropriate escrow level is used.

cc @berndartmueller @philipstanislaus @jcr-oaksec @fluffydonkey 