### PR TITLE
validate fee collector count and default page limit

### DIFF
--- a/contracts/dca/schema/dca.json
+++ b/contracts/dca/schema/dca.json
@@ -1183,11 +1183,11 @@
           "type": "object",
           "required": [
             "admin",
+            "default_page_limit",
             "default_slippage_tolerance",
             "delegation_fee_percent",
             "executors",
             "fee_collectors",
-            "page_limit",
             "paused",
             "risk_weighted_average_escrow_level",
             "swap_fee_percent",
@@ -1196,6 +1196,11 @@
           "properties": {
             "admin": {
               "$ref": "#/definitions/Addr"
+            },
+            "default_page_limit": {
+              "type": "integer",
+              "format": "uint16",
+              "minimum": 0.0
             },
             "default_slippage_tolerance": {
               "$ref": "#/definitions/Decimal"
@@ -1214,11 +1219,6 @@
               "items": {
                 "$ref": "#/definitions/FeeCollector"
               }
-            },
-            "page_limit": {
-              "type": "integer",
-              "format": "uint16",
-              "minimum": 0.0
             },
             "paused": {
               "type": "boolean"

--- a/contracts/dca/schema/raw/response_to_get_config.json
+++ b/contracts/dca/schema/raw/response_to_get_config.json
@@ -20,11 +20,11 @@
       "type": "object",
       "required": [
         "admin",
+        "default_page_limit",
         "default_slippage_tolerance",
         "delegation_fee_percent",
         "executors",
         "fee_collectors",
-        "page_limit",
         "paused",
         "risk_weighted_average_escrow_level",
         "swap_fee_percent",
@@ -33,6 +33,11 @@
       "properties": {
         "admin": {
           "$ref": "#/definitions/Addr"
+        },
+        "default_page_limit": {
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0
         },
         "default_slippage_tolerance": {
           "$ref": "#/definitions/Decimal"
@@ -51,11 +56,6 @@
           "items": {
             "$ref": "#/definitions/FeeCollector"
           }
-        },
-        "page_limit": {
-          "type": "integer",
-          "format": "uint16",
-          "minimum": 0.0
         },
         "paused": {
           "type": "boolean"

--- a/contracts/dca/src/handlers/instantiate.rs
+++ b/contracts/dca/src/handlers/instantiate.rs
@@ -2,9 +2,11 @@ use crate::{
     contract::{CONTRACT_NAME, CONTRACT_VERSION},
     error::ContractError,
     helpers::validation::{
-        assert_addresses_are_valid, assert_fee_collector_addresses_are_valid,
-        assert_fee_collector_allocations_add_up_to_one,
+        assert_addresses_are_valid, assert_default_page_limit_is_at_least_30,
+        assert_fee_collector_addresses_are_valid, assert_fee_collector_allocations_add_up_to_one,
+        assert_no_more_than_10_fee_collectors,
         assert_risk_weighted_average_escrow_level_is_less_than_100_percent,
+        assert_slippage_tolerance_is_less_than_or_equal_to_one, assert_twap_period_is_valid,
     },
     msg::InstantiateMsg,
     state::config::update_config,
@@ -16,7 +18,11 @@ use cw2::set_contract_version;
 pub fn instantiate_handler(deps: DepsMut, msg: InstantiateMsg) -> Result<Response, ContractError> {
     deps.api.addr_validate(msg.admin.as_ref())?;
 
+    assert_default_page_limit_is_at_least_30(msg.page_limit)?;
+    assert_slippage_tolerance_is_less_than_or_equal_to_one(msg.default_slippage_tolerance)?;
+    assert_twap_period_is_valid(msg.twap_period)?;
     assert_addresses_are_valid(deps.as_ref(), &msg.executors, "executor")?;
+    assert_no_more_than_10_fee_collectors(&msg.fee_collectors)?;
     assert_fee_collector_addresses_are_valid(deps.as_ref(), &msg.fee_collectors)?;
     assert_fee_collector_allocations_add_up_to_one(&msg.fee_collectors)?;
     assert_risk_weighted_average_escrow_level_is_less_than_100_percent(
@@ -31,7 +37,7 @@ pub fn instantiate_handler(deps: DepsMut, msg: InstantiateMsg) -> Result<Respons
             fee_collectors: msg.fee_collectors,
             swap_fee_percent: msg.swap_fee_percent,
             delegation_fee_percent: msg.delegation_fee_percent,
-            page_limit: msg.page_limit,
+            default_page_limit: msg.page_limit,
             paused: msg.paused,
             risk_weighted_average_escrow_level: msg.risk_weighted_average_escrow_level,
             twap_period: msg.twap_period,

--- a/contracts/dca/src/helpers/validation.rs
+++ b/contracts/dca/src/helpers/validation.rs
@@ -237,6 +237,15 @@ pub fn assert_slippage_tolerance_is_less_than_or_equal_to_one(
     Ok(())
 }
 
+pub fn assert_default_page_limit_is_at_least_30(page_limit: u16) -> Result<(), ContractError> {
+    if page_limit < 30 {
+        return Err(ContractError::CustomError {
+            val: "default page limit cannot be smaller than 30".to_string(),
+        });
+    }
+    Ok(())
+}
+
 pub fn assert_pair_exists_for_denoms(
     deps: Deps,
     swap_denom: String,
@@ -340,6 +349,17 @@ pub fn assert_fee_collector_allocations_add_up_to_one(
     Ok(())
 }
 
+pub fn assert_no_more_than_10_fee_collectors(
+    fee_collectors: &[FeeCollector],
+) -> Result<(), ContractError> {
+    if fee_collectors.len() > 10 {
+        return Err(ContractError::CustomError {
+            val: String::from("no more than 10 fee collectors are allowed"),
+        });
+    }
+    Ok(())
+}
+
 pub fn assert_risk_weighted_average_escrow_level_is_less_than_100_percent(
     risk_weighted_average_escrow_level: Decimal,
 ) -> Result<(), ContractError> {
@@ -367,9 +387,12 @@ pub fn assert_page_limit_is_valid(
     limit: Option<u16>,
 ) -> Result<(), ContractError> {
     let config = get_config(storage)?;
-    if limit.unwrap_or(30) > config.page_limit {
+    if limit.unwrap_or(30) > config.default_page_limit {
         return Err(ContractError::CustomError {
-            val: format!("limit cannot be greater than {}.", config.page_limit),
+            val: format!(
+                "limit cannot be greater than {}.",
+                config.default_page_limit
+            ),
         });
     }
     Ok(())

--- a/contracts/dca/src/tests/helpers.rs
+++ b/contracts/dca/src/tests/helpers.rs
@@ -84,7 +84,7 @@ impl Default for Config {
             }],
             swap_fee_percent: Decimal::from_str("0.0165").unwrap(),
             delegation_fee_percent: Decimal::from_str("0.0075").unwrap(),
-            page_limit: 1000,
+            default_page_limit: 1000,
             paused: false,
             risk_weighted_average_escrow_level: Decimal::from_str("0.0075").unwrap(),
             twap_period: 30,

--- a/contracts/dca/src/types/config.rs
+++ b/contracts/dca/src/types/config.rs
@@ -9,7 +9,7 @@ pub struct Config {
     pub fee_collectors: Vec<FeeCollector>,
     pub swap_fee_percent: Decimal,
     pub delegation_fee_percent: Decimal,
-    pub page_limit: u16,
+    pub default_page_limit: u16,
     pub paused: bool,
     pub risk_weighted_average_escrow_level: Decimal,
     pub twap_period: u64,


### PR DESCRIPTION
**Audit issue no. 9:** Lack of configuration parameter validation.

**Solution:** Add parameter validation for fee collector count and default page limit. Also rename `config.page_limit` to `config.default_page_limit`.

@berndartmueller @philipstanislaus @jcr-oaksec @fluffydonkey 