### PR TITLE
use same key for inverted pairs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.143"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc207893e85c5d6be840e969b496b53d94cec8be2d501b214f50daa97fa8024"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "num-derive"
@@ -716,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]

--- a/contracts/dca/src/handlers/create_pair.rs
+++ b/contracts/dca/src/handlers/create_pair.rs
@@ -91,29 +91,15 @@ mod create_pair_tests {
             route: vec![3],
         };
 
-        execute(
-            deps.as_mut(),
-            env.clone(),
-            info.clone(),
-            original_message.clone(),
-        )
-        .unwrap();
-
         execute(deps.as_mut(), env.clone(), info.clone(), original_message).unwrap();
 
-        let original_pair = find_pair(
-            deps.as_ref().storage,
-            &[DENOM_UOSMO.to_string(), DENOM_STAKE.to_string()],
-        )
-        .unwrap();
+        let denoms = [DENOM_UOSMO.to_string(), DENOM_STAKE.to_string()];
+
+        let original_pair = find_pair(deps.as_ref().storage, denoms.clone()).unwrap();
 
         execute(deps.as_mut(), env, info, message).unwrap();
 
-        let pair = find_pair(
-            deps.as_ref().storage,
-            &[DENOM_UOSMO.to_string(), DENOM_STAKE.to_string()],
-        )
-        .unwrap();
+        let pair = find_pair(deps.as_ref().storage, denoms).unwrap();
 
         assert_eq!(original_pair.route, vec![4, 1]);
         assert_eq!(pair.route, vec![3]);
@@ -193,5 +179,39 @@ mod create_pair_tests {
             result.to_string(),
             "Generic error: denom uosmo not found in pool id 2"
         )
+    }
+
+    #[test]
+    fn recreate_pair_with_switched_denoms_should_overwrite_it() {
+        let mut deps = calc_mock_dependencies();
+        let env = mock_env();
+        let info = mock_info(ADMIN, &vec![]);
+
+        instantiate_contract(deps.as_mut(), env.clone(), info.clone());
+
+        let original_message = ExecuteMsg::CreatePair {
+            quote_denom: DENOM_UOSMO.to_string(),
+            base_denom: DENOM_STAKE.to_string(),
+            route: vec![1, 4],
+        };
+
+        let message = ExecuteMsg::CreatePair {
+            base_denom: DENOM_UOSMO.to_string(),
+            quote_denom: DENOM_STAKE.to_string(),
+            route: vec![3],
+        };
+
+        execute(deps.as_mut(), env.clone(), info.clone(), original_message).unwrap();
+
+        let denoms = [DENOM_UOSMO.to_string(), DENOM_STAKE.to_string()];
+
+        let original_pair = find_pair(deps.as_ref().storage, denoms.clone()).unwrap();
+
+        execute(deps.as_mut(), env, info, message).unwrap();
+
+        let pair = find_pair(deps.as_ref().storage, denoms).unwrap();
+
+        assert_eq!(original_pair.route, vec![1, 4]);
+        assert_eq!(pair.route, vec![3]);
     }
 }

--- a/contracts/dca/src/handlers/create_vault.rs
+++ b/contracts/dca/src/handlers/create_vault.rs
@@ -94,7 +94,7 @@ pub fn create_vault_handler(
 
     let swap_denom = info.funds[0].denom.clone();
 
-    let pair = find_pair(deps.storage, &[swap_denom.clone(), target_denom.clone()])?;
+    let pair = find_pair(deps.storage, [swap_denom.clone(), target_denom.clone()])?;
 
     let swap_adjustment_strategy = swap_adjustment_strategy_params.map(|params| match params {
         SwapAdjustmentStrategyParams::RiskWeightedAverage { base_denom } => {

--- a/contracts/dca/src/handlers/disburse_escrow.rs
+++ b/contracts/dca/src/handlers/disburse_escrow.rs
@@ -44,7 +44,7 @@ pub fn disburse_escrow_handler(
         }
     }
 
-    let pair = find_pair(deps.storage, &vault.denoms())?;
+    let pair = find_pair(deps.storage, vault.denoms())?;
     let current_price = query_belief_price(&deps.as_ref(), env, &pair, vault.get_swap_denom())?;
     let performance_fee = get_performance_fee(&vault, current_price)?;
     let amount_to_disburse = subtract(&vault.escrowed_amount, &performance_fee)?;

--- a/contracts/dca/src/handlers/execute_trigger.rs
+++ b/contracts/dca/src/handlers/execute_trigger.rs
@@ -73,7 +73,7 @@ pub fn execute_trigger_handler(
 
     update_vault(deps.storage, &vault)?;
 
-    let pair = find_pair(deps.storage, &vault.denoms())?;
+    let pair = find_pair(deps.storage, vault.denoms())?;
 
     let belief_price = query_belief_price(&deps.as_ref(), &env, &pair, vault.get_swap_denom())?;
 
@@ -429,7 +429,7 @@ mod execute_trigger_tests {
             .unwrap()
             .events;
 
-        let pair = find_pair(deps.as_ref().storage, &vault.denoms()).unwrap();
+        let pair = find_pair(deps.as_ref().storage, vault.denoms()).unwrap();
 
         assert!(events.contains(&Event {
             id: 1,

--- a/contracts/dca/src/handlers/get_vault_performance.rs
+++ b/contracts/dca/src/handlers/get_vault_performance.rs
@@ -14,7 +14,7 @@ pub fn get_vault_performance_handler(
 ) -> StdResult<VaultPerformanceResponse> {
     let vault = get_vault(deps.storage, vault_id)?;
 
-    let pair = find_pair(deps.storage, &vault.denoms())?;
+    let pair = find_pair(deps.storage, vault.denoms())?;
 
     let current_price = query_belief_price(&deps, env, &pair, vault.get_swap_denom())?;
 

--- a/contracts/dca/src/helpers/validation.rs
+++ b/contracts/dca/src/helpers/validation.rs
@@ -251,7 +251,7 @@ pub fn assert_pair_exists_for_denoms(
     swap_denom: String,
     target_denom: String,
 ) -> Result<(), ContractError> {
-    find_pair(deps.storage, &[swap_denom.clone(), target_denom.clone()])
+    find_pair(deps.storage, [swap_denom.clone(), target_denom.clone()])
         .map(|_| ())
         .map_err(|_| ContractError::CustomError {
             val: format!("swapping {} to {} not supported", swap_denom, target_denom),

--- a/contracts/dca/src/helpers/vault.rs
+++ b/contracts/dca/src/helpers/vault.rs
@@ -24,7 +24,7 @@ use cosmwasm_std::{
 use std::cmp::min;
 
 pub fn get_position_type(deps: &Deps, vault: &Vault) -> StdResult<PositionType> {
-    let pair = find_pair(deps.storage, &vault.denoms())?;
+    let pair = find_pair(deps.storage, vault.denoms())?;
     Ok(pair.position_type(vault.get_swap_denom()))
 }
 
@@ -35,7 +35,7 @@ pub fn get_swap_amount(deps: &Deps, env: &Env, vault: &Vault) -> StdResult<Coin>
             multiplier,
             increase_only,
         }) => {
-            let pair = find_pair(deps.storage, &vault.denoms())?;
+            let pair = find_pair(deps.storage, vault.denoms())?;
             let belief_price = query_belief_price(deps, env, &pair, vault.get_swap_denom())?;
             let base_price = Decimal::from_ratio(vault.swap_amount, base_receive_amount);
             let scaled_price_delta = base_price.abs_diff(belief_price) / base_price * multiplier;
@@ -159,7 +159,7 @@ pub fn simulate_standard_dca_execution(
                 return Ok((vault, response));
             }
 
-            let pair = find_pair(storage, &vault.denoms())?;
+            let pair = find_pair(storage, vault.denoms())?;
 
             let actual_price = query_price(
                 querier,

--- a/contracts/dca/src/types/pair.rs
+++ b/contracts/dca/src/types/pair.rs
@@ -9,10 +9,6 @@ pub struct Pair {
 }
 
 impl Pair {
-    pub fn key(&self) -> String {
-        format!("{}-{}", self.base_denom, self.quote_denom)
-    }
-
     pub fn position_type(&self, swap_denom: String) -> PositionType {
         if self.quote_denom == swap_denom {
             PositionType::Enter


### PR DESCRIPTION
**Audit issue no. 11:** Inconsistent pair identification in storage.

**Solution:** Use `key_from` to always generate the same key for 2 denoms regardless of order. This ensures that we only ever store a single pair for any 2 denoms.

@berndartmueller @philipstanislaus @jcr-oaksec @fluffydonkey 