### PR TITLE
validate provder address for liquidity provision callback

### DIFF
--- a/contracts/dca/src/handlers/create_vault.rs
+++ b/contracts/dca/src/handlers/create_vault.rs
@@ -51,7 +51,7 @@ pub fn create_vault_handler(
     swap_adjustment_strategy_params: Option<SwapAdjustmentStrategyParams>,
 ) -> Result<Response, ContractError> {
     assert_contract_is_not_paused(deps.storage)?;
-    assert_address_is_valid(deps.as_ref(), owner.clone(), "owner")?;
+    assert_address_is_valid(deps.as_ref(), &owner, "owner")?;
     assert_exactly_one_asset(info.funds.clone())?;
     assert_swap_amount_is_greater_than_50000(swap_amount)?;
     assert_destinations_limit_is_not_breached(&destinations)?;

--- a/contracts/dca/src/handlers/z_delegate.rs
+++ b/contracts/dca/src/handlers/z_delegate.rs
@@ -16,7 +16,7 @@ pub fn z_delegate_handler(
     validator_address: Addr,
 ) -> Result<Response, ContractError> {
     assert_exactly_one_asset(info.funds.clone())?;
-    assert_address_is_valid(deps, delegator_address.clone(), "delegator address")?;
+    assert_address_is_valid(deps, &delegator_address, "delegator address")?;
     assert_validator_is_valid(deps, validator_address.to_string())?;
 
     let amount_to_delegate = info.funds[0].clone();

--- a/contracts/dca/src/handlers/z_provide_liquidity.rs
+++ b/contracts/dca/src/handlers/z_provide_liquidity.rs
@@ -1,7 +1,10 @@
 use crate::{
     constants::{AFTER_BOND_LP_TOKENS_REPLY_ID, AFTER_PROVIDE_LIQUIDITY_REPLY_ID},
     error::ContractError,
-    helpers::{authz::create_authz_exec_message, validation::assert_exactly_one_asset},
+    helpers::{
+        authz::create_authz_exec_message,
+        validation::{assert_address_is_valid, assert_exactly_one_asset},
+    },
     state::cache::{ProvideLiquidityCache, PROVIDE_LIQUIDITY_CACHE},
     types::post_execution_action::LockableDuration,
 };
@@ -24,6 +27,7 @@ pub fn z_provide_liquidity_handler(
     slippage_tolerance: Option<Decimal>,
 ) -> Result<Response, ContractError> {
     assert_exactly_one_asset(info.funds.clone())?;
+    assert_address_is_valid(deps.as_ref(), &provider_address, "provider address")?;
 
     PROVIDE_LIQUIDITY_CACHE.save(
         deps.storage,

--- a/contracts/dca/src/helpers/validation.rs
+++ b/contracts/dca/src/helpers/validation.rs
@@ -177,7 +177,7 @@ pub fn assert_destination_callback_addresses_are_valid(
     destinations: &[Destination],
 ) -> Result<(), ContractError> {
     destinations.iter().for_each(|destination| {
-        assert_address_is_valid(deps, destination.address.clone(), "destination").unwrap();
+        assert_address_is_valid(deps, &destination.address, "destination").unwrap();
     });
     Ok(())
 }
@@ -189,7 +189,7 @@ pub fn assert_fee_collector_addresses_are_valid(
     for fee_collector in fee_collectors {
         assert_address_is_valid(
             deps,
-            Addr::unchecked(fee_collector.address.clone()),
+            &Addr::unchecked(fee_collector.address.clone()),
             "fee collector",
         )?;
     }
@@ -198,7 +198,7 @@ pub fn assert_fee_collector_addresses_are_valid(
 
 pub fn assert_address_is_valid(
     deps: Deps,
-    address: Addr,
+    address: &Addr,
     label: &str,
 ) -> Result<(), ContractError> {
     deps.api
@@ -216,7 +216,7 @@ pub fn assert_addresses_are_valid(
 ) -> Result<(), ContractError> {
     addresses
         .iter()
-        .try_for_each(|address| assert_address_is_valid(deps, address.clone(), label))
+        .try_for_each(|address| assert_address_is_valid(deps, address, label))
 }
 
 pub fn assert_twap_period_is_valid(twap_period: u64) -> Result<(), ContractError> {


### PR DESCRIPTION
**Audit issue no. 14:** Lack of validation in liquidity provision cache.

**Solution:** Validate the `provider_address` before saving it to the cache.

@berndartmueller @philipstanislaus @jcr-oaksec @fluffydonkey 