### PR TITLE
pull performance fee rate into strategy impl

### DIFF
--- a/contracts/dca/src/helpers/vault.rs
+++ b/contracts/dca/src/helpers/vault.rs
@@ -266,8 +266,6 @@ pub fn simulate_standard_dca_execution(
 
 #[cfg(test)]
 mod get_swap_amount_tests {
-    use std::str::FromStr;
-
     use super::*;
     use crate::{
         constants::{ONE, SWAP_FEE_RATE, TWO_MICRONS},
@@ -284,6 +282,7 @@ mod get_swap_amount_tests {
         to_binary, StdError,
     };
     use osmosis_std::types::osmosis::twap::v1beta1::ArithmeticTwapResponse;
+    use std::str::FromStr;
 
     #[test]
     fn should_return_full_balance_when_vault_has_low_funds() {

--- a/contracts/dca/src/types/performance_assessment_strategy.rs
+++ b/contracts/dca/src/types/performance_assessment_strategy.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::Coin;
+use cosmwasm_std::{Coin, Decimal};
 
 use super::vault::Vault;
 
@@ -22,6 +22,12 @@ impl PerformanceAssessmentStrategy {
             PerformanceAssessmentStrategy::CompareToStandardDca { swapped_amount, .. } => {
                 vault.deposited_amount.amount > swapped_amount.amount
             }
+        }
+    }
+
+    pub fn performance_fee_rate(&self) -> Decimal {
+        match self {
+            PerformanceAssessmentStrategy::CompareToStandardDca { .. } => Decimal::percent(20),
         }
     }
 }


### PR DESCRIPTION
**Audit issue no. 32:** Use of magic numbers decreases maintainability

**Solution:** Pull performance fee coefficients into the performance assessment strategy implementation to make it clear what that number represents.

@berndartmueller @philipstanislaus @jcr-oaksec @fluffydonkey 