### PR TITLE
add missing wasm logging to handlers

### DIFF
--- a/contracts/dca/src/handlers/execute_trigger.rs
+++ b/contracts/dca/src/handlers/execute_trigger.rs
@@ -29,6 +29,7 @@ pub fn execute_trigger_handler(
     assert_contract_is_not_paused(deps.storage)?;
 
     let mut vault = get_vault(deps.storage, trigger_id)?;
+
     let mut response = Response::new()
         .add_attribute("execute_vault", "true")
         .add_attribute("vault_id", vault.id);
@@ -139,11 +140,11 @@ pub fn execute_trigger_handler(
             }));
         }
 
-        return Ok(response);
+        return Ok(response.add_attribute("execution_skipped", "vault_should_not_continue"));
     }
 
     if vault.is_inactive() {
-        return Ok(response);
+        return Ok(response.add_attribute("execution_skipped", "vault_is_inactive"));
     }
 
     let swap_amount = get_swap_amount(&deps.as_ref(), &env, &vault)?;
@@ -160,9 +161,7 @@ pub fn execute_trigger_handler(
             ),
         )?;
 
-        response = response.add_attribute("execution_skipped", "swap_amount_adjusted_to_zero");
-
-        return Ok(response);
+        return Ok(response.add_attribute("execution_skipped", "swap_amount_adjusted_to_zero"));
     }
 
     if price_threshold_exceeded(
@@ -183,9 +182,7 @@ pub fn execute_trigger_handler(
             ),
         )?;
 
-        response = response.add_attribute("execution_skipped", "price_threshold_exceeded");
-
-        return Ok(response);
+        return Ok(response.add_attribute("execution_skipped", "price_threshold_exceeded"));
     };
 
     VAULT_CACHE.save(deps.storage, &VaultCache { vault_id: vault.id })?;

--- a/contracts/dca/src/handlers/update_config.rs
+++ b/contracts/dca/src/handlers/update_config.rs
@@ -60,13 +60,7 @@ pub fn update_config_handler(
 
     Ok(Response::default()
         .add_attribute("method", "update_config")
-        .add_attribute("swap_fee_percent", config.swap_fee_percent.to_string())
-        .add_attribute("fee_collector", format!("{:?}", config.fee_collectors))
-        .add_attribute(
-            "delegation_fee_percent",
-            config.delegation_fee_percent.to_string(),
-        )
-        .add_attribute("paused", config.paused.to_string()))
+        .add_attribute("config", format!("{:?}", config)))
 }
 
 #[cfg(test)]

--- a/contracts/dca/src/handlers/update_swap_adjustment_handler.rs
+++ b/contracts/dca/src/handlers/update_swap_adjustment_handler.rs
@@ -15,8 +15,11 @@ pub fn update_swap_adjustment_handler(
 ) -> Result<Response, ContractError> {
     assert_sender_is_executor(deps.storage, &env, &info.sender)?;
     assert_swap_adjustment_value_is_valid(&strategy, value)?;
-    update_swap_adjustment(deps.storage, strategy, value, env.block.time)?;
-    Ok(Response::new())
+    update_swap_adjustment(deps.storage, strategy.clone(), value, env.block.time)?;
+
+    Ok(Response::new()
+        .add_attribute("strategy", format!("{:?}", strategy))
+        .add_attribute("value", value.to_string()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
**Audit issue no. 28:** Responses lacking meaningful attributes.

**Solution:** Adding appropriate wasm attributes to the handlers specified.

@berndartmueller @philipstanislaus @jcr-oaksec @fluffydonkey 