### PR TITLE
add migrate if newer guards

### DIFF
--- a/contracts/dca/src/handlers/migrate.rs
+++ b/contracts/dca/src/handlers/migrate.rs
@@ -1,7 +1,25 @@
-use crate::{error::ContractError, msg::MigrateMsg};
-use cosmwasm_std::{DepsMut, Response};
+use crate::{
+    contract::{CONTRACT_NAME, CONTRACT_VERSION},
+    error::ContractError,
+    msg::MigrateMsg,
+};
+use cosmwasm_std::{DepsMut, Response, StdError};
+use cw2::{get_contract_version, set_contract_version};
 
-pub fn migrate_handler(_deps: DepsMut, msg: MigrateMsg) -> Result<Response, ContractError> {
+pub fn migrate_handler(deps: DepsMut, msg: MigrateMsg) -> Result<Response, ContractError> {
+    let contract_version = get_contract_version(deps.storage)?;
+
+    if contract_version.contract != CONTRACT_NAME {
+        return Err(StdError::generic_err("Can only upgrade from same type").into());
+    }
+
+    #[allow(clippy::cmp_owned)]
+    if contract_version.version >= CONTRACT_VERSION.to_string() {
+        return Err(StdError::generic_err("Cannot upgrade from a newer version").into());
+    }
+
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
     Ok(Response::new()
         .add_attribute("method", "migrate")
         .add_attribute("msg", format!("{:#?}", msg)))


### PR DESCRIPTION
**Audit issue no. 31:** “Migrate only if newer” pattern is not followed

**Solution:** Add the migration guards as specified in the CosmWasm docs.

@berndartmueller @philipstanislaus @jcr-oaksec @fluffydonkey 